### PR TITLE
Fix websockets with internal proxy

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,7 @@
 BACKEND_URL="http://localhost:8080"
+# You can use the builtin webppack proxy during development which will connect you to BACKEND_URL
+REACT_APP_BACKEND_URL="http://127.0.0.1:3000"
+
 REACT_APP_CHECK_STATUS_INTERVAL="0"
 REACT_APP_TRACING_ENABLED="false"
 REACT_APP_SENTRY_DSN="https://user@sentry.com/9"

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -194,6 +194,13 @@ class ProcessDetail extends React.PureComponent<IProps, IState> {
             }
         };
 
+        // wait max 3 seconds on timeout: so non working websocket will take 3 seconds to load old process page
+        setTimeout(() => {
+            if (client.readyState === 0) {
+                client.close();
+            }
+        }, 3000);
+
         const timeout = setTimeout(() => {
             client.close(WebSocketCodes.NORMAL_CLOSURE);
             this.componentDidMount();

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -17,5 +17,5 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 
 //@ts-ignore
 module.exports = function (app) {
-    app.use("/api", createProxyMiddleware({ target: process.env.BACKEND_URL, changeOrigin: true }));
+    app.use("/api", createProxyMiddleware({ target: process.env.BACKEND_URL, changeOrigin: true, ws: true }));
 };


### PR DESCRIPTION
- added a timeout of 3 seconds on the procesdetail page for the websockets
- fixed websocket usage of proxy
- re -added some ENV items that were removed/changed after the split.