### PR TITLE
Fix tables not reloading in processes list with websockets

### DIFF
--- a/src/pages/Processes.tsx
+++ b/src/pages/Processes.tsx
@@ -65,6 +65,7 @@ class Processes extends React.PureComponent<IProps, IState> {
     updateRunningProcesses = (runningProcesses: ProcessV2[]) => {
         if (runningProcesses !== this.state.runningProcesses) {
             this.setState({ showTables: false, runningProcesses });
+            // using setTimeout to force rerender.
             setTimeout(() => {
                 this.setState({ showTables: true });
             }, 1);

--- a/src/pages/Processes.tsx
+++ b/src/pages/Processes.tsx
@@ -44,7 +44,6 @@ interface IState {
     confirmationDialogQuestion: string;
     showExplanation: boolean;
     showTables: boolean;
-    rpLength: number;
     runningProcesses: any;
 }
 
@@ -59,7 +58,6 @@ class Processes extends React.PureComponent<IProps, IState> {
             confirmationDialogQuestion: "",
             showExplanation: false,
             showTables: true,
-            rpLength: 0,
             runningProcesses: []
         };
     }
@@ -181,7 +179,6 @@ class Processes extends React.PureComponent<IProps, IState> {
                             on the reset button.
                         </p>
                     </Explain>
-                    {this.state.showTables}
                     <ConfirmationDialog
                         isOpen={this.state.confirmationDialogOpen}
                         cancel={this.cancelConfirmation}

--- a/src/pages/Processes.tsx
+++ b/src/pages/Processes.tsx
@@ -44,6 +44,8 @@ interface IState {
     confirmationDialogQuestion: string;
     showExplanation: boolean;
     showTables: boolean;
+    rpLength: number;
+    runningProcesses: any;
 }
 
 class Processes extends React.PureComponent<IProps, IState> {
@@ -57,12 +59,18 @@ class Processes extends React.PureComponent<IProps, IState> {
             confirmationDialogQuestion: "",
             showExplanation: false,
             showTables: true,
+            rpLength: 0,
+            runningProcesses: []
         };
     }
 
     updateRunningProcesses = (runningProcesses: ProcessV2[]) => {
-        this.setState({ showTables: false });
-        this.setState({ showTables: true });
+        if (runningProcesses !== this.state.runningProcesses) {
+            this.setState({ showTables: false, runningProcesses });
+            setTimeout(() => {
+                this.setState({ showTables: true });
+            }, 1);
+        }
         return <></>;
     };
 
@@ -173,6 +181,7 @@ class Processes extends React.PureComponent<IProps, IState> {
                             on the reset button.
                         </p>
                     </Explain>
+                    {this.state.showTables}
                     <ConfirmationDialog
                         isOpen={this.state.confirmationDialogOpen}
                         cancel={this.cancelConfirmation}


### PR DESCRIPTION
- change updateRunningProcesses to set showtables back to true after one milisecond.
- also change it to update only when the list changes, otherwise it infinite loops for some reason.