### PR TITLE
Update websocket process detail

### DIFF
--- a/src/components/ProcessStateDetails.tsx
+++ b/src/components/ProcessStateDetails.tsx
@@ -19,7 +19,6 @@ import { EuiButton, EuiCheckbox, EuiCopy, EuiIcon, EuiText } from "@elastic/eui"
 import HighlightCode from "components/HighlightCode";
 import StepDetails from "components/Step";
 import isEqual from "lodash/isEqual";
-import { CustomProcessWithDetails } from "pages/ProcessDetail";
 import { useContext, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import ApplicationContext from "utils/ApplicationContext";
@@ -241,14 +240,24 @@ function ProcessOverview({
 }
 
 interface IProps {
-    process: CustomProcessWithDetails;
+    process: ProcessWithDetails;
+    productName: string;
+    customerName: string;
     subscriptionProcesses: ProcessSubscription[];
     collapsed?: number[];
     onChangeCollapsed: (index: number) => void; // when provided it will toggle the collapse functionality
     isProcess: boolean;
 }
 
-function ProcessStateDetails({ process, subscriptionProcesses, isProcess, onChangeCollapsed, collapsed = [] }: IProps) {
+function ProcessStateDetails({
+    process,
+    productName,
+    customerName,
+    subscriptionProcesses,
+    isProcess,
+    onChangeCollapsed,
+    collapsed = [],
+}: IProps) {
     const [raw, setRaw] = useState(false);
     const [details, setDetails] = useState(true);
     const [stateChanges, setStateChanges] = useState(true);
@@ -264,7 +273,7 @@ function ProcessStateDetails({ process, subscriptionProcesses, isProcess, onChan
     const renderSummaryValue = (value: string | number | any) =>
         typeof value === "string" ? capitalize(value) : typeof value === "number" ? renderDateTime(value) : value;
 
-    const renderRaw = (process: CustomProcessWithDetails) => {
+    const renderRaw = (process: ProcessWithDetails) => {
         const json = JSON.stringify(process, null, 4);
         return (
             <section>
@@ -282,7 +291,7 @@ function ProcessStateDetails({ process, subscriptionProcesses, isProcess, onChan
         );
     };
 
-    const renderProcessHeaderInformation = (process: CustomProcessWithDetails) => {
+    const renderProcessHeaderInformation = (process: ProcessWithDetails) => {
         return (
             <section className="header-information">
                 <ul>
@@ -293,8 +302,8 @@ function ProcessStateDetails({ process, subscriptionProcesses, isProcess, onChan
                                     <FormattedMessage
                                         id="process_state.wording_process"
                                         values={{
-                                            product: process.productName,
-                                            customer: process.customerName,
+                                            product: productName,
+                                            customer: customerName,
                                             workflow: process.workflow_name,
                                         }}
                                     />

--- a/src/components/failedTaskBanner/index.tsx
+++ b/src/components/failedTaskBanner/index.tsx
@@ -67,10 +67,7 @@ export default function FailedTaskBanner() {
     const [failedProcesses, setFailedProcesses] = useState<FailedProcess[]>([]);
     const [failedTasks, setFailedTasks] = useState(countFailedProcesses([]));
 
-    useHttpIntervalFallback(
-        RunningProcessesContext,
-        () => fetchData(0, 10, [], filterFailedTasks)
-    );
+    useHttpIntervalFallback(RunningProcessesContext, () => fetchData(0, 10, [], filterFailedTasks));
 
     useEffect(() => {
         const newList = [...data, ...runningProcesses.filter((p) => failedProcessStatuses.includes(p.last_status))];

--- a/src/components/failedTaskBanner/index.tsx
+++ b/src/components/failedTaskBanner/index.tsx
@@ -20,6 +20,7 @@ import { groupBy } from "lodash";
 import { useContext, useEffect, useState } from "react";
 import { Process, ProcessStatus } from "utils/types";
 import useHttpIntervalFallback from "utils/useHttpIntervalFallback";
+import { FailedProcess } from "websocketService/useRunningProcesses";
 import RunningProcessesContext from "websocketService/useRunningProcesses/RunningProcessesContext";
 
 import useFailedTaskFetcher from "./useFailedTaskFetcher";
@@ -37,9 +38,17 @@ interface ProcessWithStatus {
     last_status: string;
 }
 
-const filterFailedTasks = [{ id: "status", values: ["failed", "api_unavailable", "inconsistent_data"] }];
+interface CountFailedProcesses {
+    failed: number;
+    inconsistentData: number;
+    apiUnavailable: number;
+    all: number;
+}
 
-const countFailedProcesses = (processes: ProcessWithStatus[]) => {
+const failedProcessStatuses = ["failed", "api_unavailable", "inconsistent_data"];
+const filterFailedTasks = [{ id: "status", values: failedProcessStatuses }];
+
+const countFailedProcesses = (processes: ProcessWithStatus[]): CountFailedProcesses => {
     const groupStatuses = groupBy(processes, (p) => p.last_status);
     const failed = groupStatuses[ProcessStatus.FAILED]?.length || 0;
     const inconsistentData = groupStatuses[ProcessStatus.INCONSISTENT_DATA]?.length || 0;
@@ -53,19 +62,24 @@ const countFailedProcesses = (processes: ProcessWithStatus[]) => {
 };
 
 export default function FailedTaskBanner() {
-    const { runningProcesses } = useContext(RunningProcessesContext);
-    const [failedTasks, setFailedTasks] = useState(countFailedProcesses(runningProcesses));
-    const [data, , fetchData] = useFailedTaskFetcher<ProcessWithStatus>("processes/");
+    const { runningProcesses, completedProcessIds } = useContext(RunningProcessesContext);
+    const [data, , fetchData] = useFailedTaskFetcher<FailedProcess>("processes/");
+    const [failedProcesses, setFailedProcesses] = useState<FailedProcess[]>([]);
+    const [failedTasks, setFailedTasks] = useState(countFailedProcesses([]));
 
-    useHttpIntervalFallback(RunningProcessesContext, () => fetchData(0, 10, [], filterFailedTasks));
+    useHttpIntervalFallback(
+        RunningProcessesContext,
+        () => fetchData(0, 10, [], filterFailedTasks)
+    );
 
     useEffect(() => {
-        setFailedTasks(countFailedProcesses(runningProcesses));
-    }, [runningProcesses]);
+        const newList = [...data, ...runningProcesses.filter((p) => failedProcessStatuses.includes(p.last_status))];
+        setFailedProcesses(newList.filter((p) => !completedProcessIds.includes(p.pid)));
+    }, [data, runningProcesses, completedProcessIds]);
 
     useEffect(() => {
-        setFailedTasks(countFailedProcesses(data));
-    }, [data]);
+        setFailedTasks(countFailedProcesses(failedProcesses));
+    }, [failedProcesses]);
 
     useEffect(() => {
         fetchData(0, 10, [], filterFailedTasks);

--- a/src/components/failedTaskBanner/index.tsx
+++ b/src/components/failedTaskBanner/index.tsx
@@ -62,12 +62,12 @@ const countFailedProcesses = (processes: ProcessWithStatus[]): CountFailedProces
 };
 
 export default function FailedTaskBanner() {
-    const { runningProcesses, completedProcessIds } = useContext(RunningProcessesContext);
+    const { runningProcesses, completedProcessIds, useFallback } = useContext(RunningProcessesContext);
     const [data, , fetchData] = useFailedTaskFetcher<FailedProcess>("processes/");
     const [failedProcesses, setFailedProcesses] = useState<FailedProcess[]>([]);
     const [failedTasks, setFailedTasks] = useState(countFailedProcesses([]));
 
-    useHttpIntervalFallback(RunningProcessesContext, () => fetchData(0, 10, [], filterFailedTasks));
+    useHttpIntervalFallback(useFallback, () => fetchData(0, 10, [], filterFailedTasks));
 
     useEffect(() => {
         const newList = [...data, ...runningProcesses.filter((p) => failedProcessStatuses.includes(p.last_status))];

--- a/src/components/tables/NwaTable.tsx
+++ b/src/components/tables/NwaTable.tsx
@@ -212,7 +212,7 @@ export function NwaTable<T extends object>({
     excludeInFilter,
     advancedSearch,
 }: INwaTableProps<T>) {
-    const { runningProcesses } = useContext(RunningProcessesContext);
+    const { runningProcesses, useFallback } = useContext(RunningProcessesContext);
     const [data, pageCount, fetchData] = useFilterableDataFetcher<T>(endpoint);
     const {
         getTableProps,
@@ -301,7 +301,7 @@ export function NwaTable<T extends object>({
         previousPage,
         setPageSize,
     };
-    useHttpIntervalFallback(RunningProcessesContext, () => fetchData(dispatch, pageIndex, pageSize, sortBy, filterBy));
+    useHttpIntervalFallback(useFallback, () => fetchData(dispatch, pageIndex, pageSize, sortBy, filterBy));
 
     // Update localStorage
     useEffect(() => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -203,10 +203,12 @@ export interface FormNotCompleteResponse {
     hasNext?: boolean;
 }
 
+export type Assignee = "NOC" | "CHANGES" | "SYSTEM" | "KLANT_SUPPORT";
+
 export interface Process {
     pid: string;
     workflow: string;
-    assignee: "NOC" | "CHANGES" | "SYSTEM" | "KLANT_SUPPORT";
+    assignee: Assignee;
     last_status: string;
     failed_reason: string;
     traceback: string;
@@ -222,7 +224,7 @@ export interface ProcessWithDetails {
     workflow_name: string;
     product: string;
     customer: string;
-    assignee: "NOC" | "CHANGES" | "SYSTEM" | "KLANT_SUPPORT";
+    assignee: Assignee;
     status: string;
     failed_reason: string;
     traceback: string;
@@ -245,11 +247,11 @@ export interface ProcessSubscription {
 }
 
 export interface ProcessV2 {
-    assignee: string;
+    pid: string;
+    assignee: Assignee;
     created_by: string;
     failed_reason: string;
     last_modified_at: string;
-    pid: string;
     started_at: string;
     last_status: string;
     last_step: string;
@@ -257,6 +259,15 @@ export interface ProcessV2 {
     workflow: string;
     workflow_target: string;
     is_task: boolean;
+}
+
+export interface WsProcessV2 extends ProcessV2 {
+    id: string;
+    status: ProcessStatus;
+    form: InputForm;
+    steps: Step[];
+    traceback: string;
+    step: string;
 }
 
 export interface Step {

--- a/src/utils/useHttpIntervalFallback.ts
+++ b/src/utils/useHttpIntervalFallback.ts
@@ -13,11 +13,9 @@
  *
  */
 
-import { Context, useContext, useEffect, useState } from "react";
-import { RunningProcesses } from "websocketService/useRunningProcesses";
+import { useEffect, useState } from "react";
 
-const useHttpIntervalFallback = (context: Context<RunningProcesses>, fn: () => void) => {
-    const { useFallback } = useContext(context);
+const useHttpIntervalFallback = (useFallback: boolean, fn: () => void) => {
     const [httpInterval, setHttpInterval] = useState<NodeJS.Timeout | undefined>();
 
     useEffect(() => {

--- a/src/websocketService/useRunningProcesses/RunningProcessesContext.tsx
+++ b/src/websocketService/useRunningProcesses/RunningProcessesContext.tsx
@@ -1,25 +1,21 @@
 import React from "react";
 
-import useRunningProcesses, { RunningProcess } from ".";
+import useRunningProcesses, { RunningProcesses } from ".";
 
-interface RunningProcessesContextState {
-    runningProcesses: RunningProcess[];
-    useFallback: boolean;
-}
-
-const RunningProcessesContext = React.createContext<RunningProcessesContextState>({
+const RunningProcessesContext = React.createContext<RunningProcesses>({
     runningProcesses: [],
+    completedProcessIds: [],
     useFallback: false,
 });
 export const RunningProcessesProvider = RunningProcessesContext.Provider;
 export default RunningProcessesContext;
 
 export function RunningProcessesContextWrapper({ children }: any) {
-    const { runningProcesses, useFallback } = useRunningProcesses();
+    const data = useRunningProcesses();
 
     return (
         <div>
-            <RunningProcessesProvider value={{ runningProcesses, useFallback }}>{children}</RunningProcessesProvider>
+            <RunningProcessesProvider value={data}>{children}</RunningProcessesProvider>
         </div>
     );
 }

--- a/src/websocketService/useWebsocket.ts
+++ b/src/websocketService/useWebsocket.ts
@@ -42,6 +42,9 @@ const useWebsocket = <T extends object>(
             newClient.onerror = () => {
                 setUsefallback(true);
             };
+            newClient.close = () => {
+                setUsefallback(true);
+            };
             client.current = newClient;
         }
 


### PR DESCRIPTION
- change ProcessDetail to use RunningProcessesContext and remove old websocket logic.
- update RunningProcessesContext to keep track of completed processes.
- update failedTaskBanner to initially fetch failed processes with http request.
- move productName and customerName in ProcessDetail to the state and remove CustomProcessWithDetails.
- change RunningProcessesContext processes type to `WsProcessV2`.

Depend on orchestrator core update: https://github.com/workfloworchestrator/orchestrator-core/pull/74