### PR TITLE
Change engine status data to come from websocket with http as fallback

### DIFF
--- a/src/components/Header.scss
+++ b/src/components/Header.scss
@@ -42,19 +42,6 @@
         margin-top: 1.5rem;
         width: 16rem;
     }
-    &__status {
-        font-size: 115%;
-        margin-left: 5px;
-        &.paused {
-            color: vars.$danger;
-        }
-        &.pausing {
-            color: vars.$warning;
-        }
-        &.running {
-            color: vars.$success;
-        }
-    }
 }
 
 .flash.hide + div.header-container {

--- a/src/components/engineStatusBanner/EngineStatusBanner.scss
+++ b/src/components/engineStatusBanner/EngineStatusBanner.scss
@@ -18,6 +18,12 @@
 @use "../../stylesheets/vars";
 
 .engine-status-banner {
+    margin: 0 16px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,
+        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
     &__status {
         font-size: 115%;
         margin-left: 5px;

--- a/src/components/engineStatusBanner/EngineStatusBanner.scss
+++ b/src/components/engineStatusBanner/EngineStatusBanner.scss
@@ -13,7 +13,7 @@
  *
  */
 
- @use "../../stylesheets/mixins.scss";
+@use "../../stylesheets/mixins.scss";
 @use "../../stylesheets/media_queries.scss";
 @use "../../stylesheets/vars";
 

--- a/src/components/engineStatusBanner/EngineStatusBanner.scss
+++ b/src/components/engineStatusBanner/EngineStatusBanner.scss
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2019-2020 SURF.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+ @use "../../stylesheets/mixins.scss";
+@use "../../stylesheets/media_queries.scss";
+@use "../../stylesheets/vars";
+
+.engine-status-banner {
+    &__status {
+        font-size: 115%;
+        margin-left: 5px;
+        &.paused {
+            color: vars.$danger;
+        }
+        &.pausing {
+            color: vars.$warning;
+        }
+        &.running {
+            color: vars.$success;
+        }
+    }
+}

--- a/src/components/engineStatusBanner/index.tsx
+++ b/src/components/engineStatusBanner/index.tsx
@@ -15,20 +15,18 @@
 
 import "./EngineStatusBanner.scss";
 
-import { EuiHeaderLink } from "@elastic/eui";
 import EngineSettingsContext from "contextProviders/engineSettingsProvider";
 import { useContext } from "react";
 import { FormattedMessage } from "react-intl";
 
 export default function EngineStatusBanner() {
     const { engineStatus } = useContext(EngineSettingsContext);
+    const globalStatus = engineStatus.global_status.toLocaleLowerCase();
 
     return (
-        <EuiHeaderLink href="#">
-            <FormattedMessage id={`settings.status.engine.${engineStatus.global_status.toLocaleLowerCase()}`} />
-            <i
-                className={`fa fa-circle engine-status-banner__status ${engineStatus.global_status.toLocaleLowerCase()}`}
-            ></i>
-        </EuiHeaderLink>
+        <div className="engine-status-banner">
+            <FormattedMessage id={`settings.status.engine.${globalStatus}`} />
+            <i className={`fa fa-circle engine-status-banner__status ${globalStatus}`}></i>
+        </div>
     );
 }

--- a/src/components/engineStatusBanner/index.tsx
+++ b/src/components/engineStatusBanner/index.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019-2020 SURF.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import './EngineStatusBanner.scss'
+import { EuiHeaderLink } from "@elastic/eui";
+import EngineSettingsContext from "contextProviders/engineSettingsProvider";
+import { useContext } from "react";
+import { FormattedMessage } from "react-intl";
+
+export default function EngineStatusBanner() {
+    const { engineStatus } = useContext(EngineSettingsContext);
+
+    return (
+        <EuiHeaderLink href="#">
+            <FormattedMessage id={`settings.status.engine.${engineStatus.global_status.toLocaleLowerCase()}`} />
+            <i className={`fa fa-circle engine-status-banner__status ${engineStatus.global_status.toLocaleLowerCase()}`}></i>
+        </EuiHeaderLink>
+    );
+}

--- a/src/components/engineStatusBanner/index.tsx
+++ b/src/components/engineStatusBanner/index.tsx
@@ -13,7 +13,8 @@
  *
  */
 
-import './EngineStatusBanner.scss'
+import "./EngineStatusBanner.scss";
+
 import { EuiHeaderLink } from "@elastic/eui";
 import EngineSettingsContext from "contextProviders/engineSettingsProvider";
 import { useContext } from "react";
@@ -25,7 +26,9 @@ export default function EngineStatusBanner() {
     return (
         <EuiHeaderLink href="#">
             <FormattedMessage id={`settings.status.engine.${engineStatus.global_status.toLocaleLowerCase()}`} />
-            <i className={`fa fa-circle engine-status-banner__status ${engineStatus.global_status.toLocaleLowerCase()}`}></i>
+            <i
+                className={`fa fa-circle engine-status-banner__status ${engineStatus.global_status.toLocaleLowerCase()}`}
+            ></i>
         </EuiHeaderLink>
     );
 }

--- a/src/components/failedTaskBanner/index.tsx
+++ b/src/components/failedTaskBanner/index.tsx
@@ -16,12 +16,12 @@
 import "./FailedTaskBanner.scss";
 
 import { EuiText, EuiToolTip } from "@elastic/eui";
+import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 import { groupBy } from "lodash";
 import { useContext, useEffect, useState } from "react";
 import { Process, ProcessStatus } from "utils/types";
 import useHttpIntervalFallback from "utils/useHttpIntervalFallback";
 import { FailedProcess } from "websocketService/useRunningProcesses";
-import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 
 import useFailedTaskFetcher from "./useFailedTaskFetcher";
 

--- a/src/components/failedTaskBanner/index.tsx
+++ b/src/components/failedTaskBanner/index.tsx
@@ -21,7 +21,7 @@ import { useContext, useEffect, useState } from "react";
 import { Process, ProcessStatus } from "utils/types";
 import useHttpIntervalFallback from "utils/useHttpIntervalFallback";
 import { FailedProcess } from "websocketService/useRunningProcesses";
-import RunningProcessesContext from "websocketService/useRunningProcesses/RunningProcessesContext";
+import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 
 import useFailedTaskFetcher from "./useFailedTaskFetcher";
 

--- a/src/components/tables/NwaTable.tsx
+++ b/src/components/tables/NwaTable.tsx
@@ -41,9 +41,9 @@ import {
     useTable,
 } from "react-table";
 import useHttpIntervalFallback from "utils/useHttpIntervalFallback";
-import RunningProcessesContext from "websocketService/useRunningProcesses/RunningProcessesContext";
 
 import MiniPaginator from "./MiniPaginator";
+import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 
 /*
  * Reusable NWA table implementation using react-table 7.

--- a/src/components/tables/NwaTable.tsx
+++ b/src/components/tables/NwaTable.tsx
@@ -22,6 +22,7 @@ import Paginator from "components/tables/Paginator";
 import Preferences from "components/tables/Preferences";
 import { TableRenderer } from "components/tables/TableRenderer";
 import useFilterableDataFetcher from "components/tables/useFilterableDataFetcher";
+import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 import { produce } from "immer";
 import { useContext, useEffect } from "react";
 import { FormattedMessage } from "react-intl";
@@ -43,7 +44,6 @@ import {
 import useHttpIntervalFallback from "utils/useHttpIntervalFallback";
 
 import MiniPaginator from "./MiniPaginator";
-import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 
 /*
  * Reusable NWA table implementation using react-table 7.

--- a/src/contextProviders/engineSettingsProvider/index.tsx
+++ b/src/contextProviders/engineSettingsProvider/index.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019-2020 SURF.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import ApplicationContext from "utils/ApplicationContext";
+import { EngineStatus } from "utils/types";
+import useHttpIntervalFallback from "utils/useHttpIntervalFallback";
+import useWebsocket from "websocketService/useWebsocket";
+
+interface WebSocketMessageData {
+    "engine-status": EngineStatus;
+}
+
+export interface EngineSettingsContextData {
+    engineStatus: EngineStatus;
+    useFallback: boolean;
+}
+
+const defaultEngineSettings: EngineStatus = {
+    global_lock: false,
+    running_processes: 0,
+    global_status: "RUNNING",
+};
+
+const EngineSettingsContext = createContext<EngineSettingsContextData>({
+    engineStatus: defaultEngineSettings,
+    useFallback: false,
+});
+
+export const RunningProcessesProvider = EngineSettingsContext.Provider;
+export default EngineSettingsContext;
+
+export function EngineSettingsContextWrapper({ children }: any) {
+    const { apiClient } = useContext(ApplicationContext);
+    const { message, useFallback } = useWebsocket<WebSocketMessageData>("api/settings/ws-status/");
+    const [engineStatus, setEngineStatus] = useState<EngineStatus>({
+        global_lock: false,
+        running_processes: 0,
+        global_status: "RUNNING",
+    });
+
+    const getEngineStatus = useCallback(() => {
+        apiClient.getGlobalStatus().then((newEngineStatus) => {
+            setEngineStatus(newEngineStatus);
+        });
+    }, [setEngineStatus, apiClient]);
+
+    useHttpIntervalFallback(useFallback, getEngineStatus);
+
+    useEffect(() => {
+        if (message["engine-status"]) {
+            setEngineStatus(message["engine-status"]);
+        }
+    }, [message]);
+
+    return <RunningProcessesProvider value={{ engineStatus, useFallback }}>{children}</RunningProcessesProvider>;
+}

--- a/src/contextProviders/globalContextProviders.tsx
+++ b/src/contextProviders/globalContextProviders.tsx
@@ -1,6 +1,5 @@
-import { RunningProcessesContextWrapper } from "./runningProcessesProvider";
-
 import { EngineSettingsContextWrapper } from "./engineSettingsProvider";
+import { RunningProcessesContextWrapper } from "./runningProcessesProvider";
 
 export default function GlobalContextProviders({ children }: any) {
     return (

--- a/src/contextProviders/globalContextProviders.tsx
+++ b/src/contextProviders/globalContextProviders.tsx
@@ -1,0 +1,11 @@
+import { RunningProcessesContextWrapper } from "./runningProcessesProvider";
+
+import { EngineSettingsContextWrapper } from "./engineSettingsProvider";
+
+export default function GlobalContextProviders({ children }: any) {
+    return (
+        <RunningProcessesContextWrapper>
+            <EngineSettingsContextWrapper>{children}</EngineSettingsContextWrapper>
+        </RunningProcessesContextWrapper>
+    );
+}

--- a/src/contextProviders/runningProcessesProvider/index.tsx
+++ b/src/contextProviders/runningProcessesProvider/index.tsx
@@ -1,21 +1,17 @@
 import React from "react";
-
-import useRunningProcesses, { RunningProcesses } from ".";
+import useRunningProcesses, { RunningProcesses } from "websocketService/useRunningProcesses";
 
 const RunningProcessesContext = React.createContext<RunningProcesses>({
     runningProcesses: [],
     completedProcessIds: [],
     useFallback: false,
 });
+
 export const RunningProcessesProvider = RunningProcessesContext.Provider;
 export default RunningProcessesContext;
 
 export function RunningProcessesContextWrapper({ children }: any) {
     const data = useRunningProcesses();
 
-    return (
-        <div>
-            <RunningProcessesProvider value={data}>{children}</RunningProcessesProvider>
-        </div>
-    );
+    return <RunningProcessesProvider value={data}>{children}</RunningProcessesProvider>;
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -228,132 +228,132 @@ class App extends React.PureComponent<IProps, IState> {
                 <Router history={history}>
                     <QueryParamProvider ReactRouterRoute={Route}>
                         <ApplicationContext.Provider value={applicationContext}>
-                                <RawIntlProvider value={intl}>
-                                    <GlobalContextProviders>
-                                        {loading && (
-                                            <EuiToast className="sync" color="primary">
-                                                <EuiLoadingSpinner size="m" />
-                                                <h6 className="sync__label">Syncing</h6>
-                                            </EuiToast>
-                                        )}
+                            <RawIntlProvider value={intl}>
+                                <GlobalContextProviders>
+                                    {loading && (
+                                        <EuiToast className="sync" color="primary">
+                                            <EuiLoadingSpinner size="m" />
+                                            <h6 className="sync__label">Syncing</h6>
+                                        </EuiToast>
+                                    )}
+                                    <div>
+                                        <ReactQueryDevtools initialIsOpen={false} position={"bottom-right"} />
                                         <div>
-                                            <ReactQueryDevtools initialIsOpen={false} position={"bottom-right"} />
-                                            <div>
-                                                <Flash />
-                                                <Header />
-                                                <Navigation extraPages={importedModules.map((i) => i.name)} />
-                                                <ErrorDialog isOpen={errorDialogOpen} close={errorDialogAction} />
-                                            </div>
-                                            <Switch>
-                                                <Route exact path="/authorize" render={() => <Redirect to="/" />} />
-                                                <Route exact path="/" render={() => <Redirect to="/processes" />} />
-                                                <ProtectedRoute
-                                                    path="/new-process"
-                                                    render={(props) => (
-                                                        <NewProcess
-                                                            preselectedInput={getQueryParameters(props.location.search)}
-                                                        />
-                                                    )}
-                                                />
-                                                <ProtectedRoute
-                                                    path="/modify-subscription"
-                                                    render={(props) => (
-                                                        <ModifySubscription
-                                                            workflowName={getParameterByName(
-                                                                "workflow",
-                                                                props.location.search
-                                                            )}
-                                                            subscriptionId={getParameterByName(
-                                                                "subscription",
-
-                                                                props.location.search
-                                                            )}
-                                                        />
-                                                    )}
-                                                />
-                                                <ProtectedRoute
-                                                    path="/terminate-subscription"
-                                                    render={(props) => (
-                                                        <TerminateSubscription
-                                                            subscriptionId={getParameterByName(
-                                                                "subscription",
-
-                                                                props.location.search
-                                                            )}
-                                                        />
-                                                    )}
-                                                />
-                                                <Route
-                                                    path="/process/:id"
-                                                    render={(props) => (
-                                                        <Redirect to={`/processes/${props.match.params.id}`} />
-                                                    )}
-                                                />
-                                                <Route
-                                                    path="/processes/:id"
-                                                    render={(props) => <ProcessDetail {...props} />}
-                                                />
-                                                <ProtectedRoute path="/processes" render={(props) => <Processes />} />
-                                                <Route
-                                                    path="/subscription/:id"
-                                                    render={(props) => (
-                                                        <Redirect to={`/subscriptions/${props.match.params.id}`} />
-                                                    )}
-                                                />
-                                                {!disabledRoutes.includes("/subscriptions/:id") && (
-                                                    <Route
-                                                        path="/subscriptions/:id"
-                                                        render={(props) => <SubscriptionDetailPage {...props} />}
-                                                    />
-                                                )}
-                                                {!disabledRoutes.includes("/subscriptions") && (
-                                                    <Route
-                                                        path="/subscriptions"
-                                                        render={(props) => <SubscriptionsPage {...props} />}
-                                                    />
-                                                )}
-                                                {!disabledRoutes.includes("/metadata") && (
-                                                    <Route
-                                                        exact
-                                                        path="/metadata"
-                                                        render={() => <Redirect to="/metadata/products" />}
-                                                    />
-                                                )}
-                                                <ProtectedRoute
-                                                    path="/metadata/product-block/:id"
-                                                    render={(props) => <ProductBlock {...props} />}
-                                                />
-                                                <ProtectedRoute
-                                                    path="/metadata/product/:id"
-                                                    render={(props) => <ProductPage {...props} />}
-                                                />
-                                                <ProtectedRoute
-                                                    path="/metadata/:type"
-                                                    render={(props) => (
-                                                        <MetaData selectedTab={props.match.params.type} {...props} />
-                                                    )}
-                                                />
-                                                {!disabledRoutes.includes("/metadata") && (
-                                                    <ProtectedRoute path="/settings" render={() => <Settings />} />
-                                                )}
-
-                                                {!isEmpty(importedModules) &&
-                                                    importedModules.map(({ path, name, Component }) => (
-                                                        <Route key={path} exact path={`/${name}`} component={Component} />
-                                                    ))}
-
-                                                <ProtectedRoute path="/new-task" render={() => <NewTask />} />
-
-                                                <ProtectedRoute path="/tasks" render={() => <Tasks />} />
-                                                <Route path="/task/:id" render={(props) => <ProcessDetail {...props} />} />
-                                                <Route path="/not-allowed" render={() => <NotAllowed />} />
-                                                <Route path="/error" render={(props) => <ServerError {...props} />} />
-                                                <Route path="/styleguide" render={(props) => <StyleGuide {...props} />} />
-                                                <Route component={NotFound} />
-                                            </Switch>
+                                            <Flash />
+                                            <Header />
+                                            <Navigation extraPages={importedModules.map((i) => i.name)} />
+                                            <ErrorDialog isOpen={errorDialogOpen} close={errorDialogAction} />
                                         </div>
-                                    </GlobalContextProviders>
-                                </RawIntlProvider>
+                                        <Switch>
+                                            <Route exact path="/authorize" render={() => <Redirect to="/" />} />
+                                            <Route exact path="/" render={() => <Redirect to="/processes" />} />
+                                            <ProtectedRoute
+                                                path="/new-process"
+                                                render={(props) => (
+                                                    <NewProcess
+                                                        preselectedInput={getQueryParameters(props.location.search)}
+                                                    />
+                                                )}
+                                            />
+                                            <ProtectedRoute
+                                                path="/modify-subscription"
+                                                render={(props) => (
+                                                    <ModifySubscription
+                                                        workflowName={getParameterByName(
+                                                            "workflow",
+                                                            props.location.search
+                                                        )}
+                                                        subscriptionId={getParameterByName(
+                                                            "subscription",
+
+                                                            props.location.search
+                                                        )}
+                                                    />
+                                                )}
+                                            />
+                                            <ProtectedRoute
+                                                path="/terminate-subscription"
+                                                render={(props) => (
+                                                    <TerminateSubscription
+                                                        subscriptionId={getParameterByName(
+                                                            "subscription",
+
+                                                            props.location.search
+                                                        )}
+                                                    />
+                                                )}
+                                            />
+                                            <Route
+                                                path="/process/:id"
+                                                render={(props) => (
+                                                    <Redirect to={`/processes/${props.match.params.id}`} />
+                                                )}
+                                            />
+                                            <Route
+                                                path="/processes/:id"
+                                                render={(props) => <ProcessDetail {...props} />}
+                                            />
+                                            <ProtectedRoute path="/processes" render={(props) => <Processes />} />
+                                            <Route
+                                                path="/subscription/:id"
+                                                render={(props) => (
+                                                    <Redirect to={`/subscriptions/${props.match.params.id}`} />
+                                                )}
+                                            />
+                                            {!disabledRoutes.includes("/subscriptions/:id") && (
+                                                <Route
+                                                    path="/subscriptions/:id"
+                                                    render={(props) => <SubscriptionDetailPage {...props} />}
+                                                />
+                                            )}
+                                            {!disabledRoutes.includes("/subscriptions") && (
+                                                <Route
+                                                    path="/subscriptions"
+                                                    render={(props) => <SubscriptionsPage {...props} />}
+                                                />
+                                            )}
+                                            {!disabledRoutes.includes("/metadata") && (
+                                                <Route
+                                                    exact
+                                                    path="/metadata"
+                                                    render={() => <Redirect to="/metadata/products" />}
+                                                />
+                                            )}
+                                            <ProtectedRoute
+                                                path="/metadata/product-block/:id"
+                                                render={(props) => <ProductBlock {...props} />}
+                                            />
+                                            <ProtectedRoute
+                                                path="/metadata/product/:id"
+                                                render={(props) => <ProductPage {...props} />}
+                                            />
+                                            <ProtectedRoute
+                                                path="/metadata/:type"
+                                                render={(props) => (
+                                                    <MetaData selectedTab={props.match.params.type} {...props} />
+                                                )}
+                                            />
+                                            {!disabledRoutes.includes("/metadata") && (
+                                                <ProtectedRoute path="/settings" render={() => <Settings />} />
+                                            )}
+
+                                            {!isEmpty(importedModules) &&
+                                                importedModules.map(({ path, name, Component }) => (
+                                                    <Route key={path} exact path={`/${name}`} component={Component} />
+                                                ))}
+
+                                            <ProtectedRoute path="/new-task" render={() => <NewTask />} />
+
+                                            <ProtectedRoute path="/tasks" render={() => <Tasks />} />
+                                            <Route path="/task/:id" render={(props) => <ProcessDetail {...props} />} />
+                                            <Route path="/not-allowed" render={() => <NotAllowed />} />
+                                            <Route path="/error" render={(props) => <ServerError {...props} />} />
+                                            <Route path="/styleguide" render={(props) => <StyleGuide {...props} />} />
+                                            <Route component={NotFound} />
+                                        </Switch>
+                                    </div>
+                                </GlobalContextProviders>
+                            </RawIntlProvider>
                         </ApplicationContext.Provider>
                     </QueryParamProvider>
                 </Router>

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -26,6 +26,7 @@ import Navigation from "components/Navigation";
 import ProductPage from "components/Product";
 import ProductBlock from "components/ProductBlock";
 import ProtectedRoute from "components/ProtectedRoute";
+import GlobalContextProviders from "contextProviders/globalContextProviders";
 import { customPages, disabledRoutes } from "custom/manifest.json";
 import { createBrowserHistory } from "history";
 import { intl, setLocale } from "locale/i18n";
@@ -56,7 +57,6 @@ import { createPolicyCheck } from "utils/policy";
 import { getParameterByName, getQueryParameters } from "utils/QueryParameters";
 import { AppError } from "utils/types";
 import { isEmpty } from "utils/Utils";
-import { RunningProcessesContextWrapper } from "websocketService/useRunningProcesses/RunningProcessesContext";
 
 export const history = createBrowserHistory();
 
@@ -228,132 +228,132 @@ class App extends React.PureComponent<IProps, IState> {
                 <Router history={history}>
                     <QueryParamProvider ReactRouterRoute={Route}>
                         <ApplicationContext.Provider value={applicationContext}>
-                            <RunningProcessesContextWrapper>
                                 <RawIntlProvider value={intl}>
-                                    {loading && (
-                                        <EuiToast className="sync" color="primary">
-                                            <EuiLoadingSpinner size="m" />
-                                            <h6 className="sync__label">Syncing</h6>
-                                        </EuiToast>
-                                    )}
-                                    <div>
-                                        <ReactQueryDevtools initialIsOpen={false} position={"bottom-right"} />
+                                    <GlobalContextProviders>
+                                        {loading && (
+                                            <EuiToast className="sync" color="primary">
+                                                <EuiLoadingSpinner size="m" />
+                                                <h6 className="sync__label">Syncing</h6>
+                                            </EuiToast>
+                                        )}
                                         <div>
-                                            <Flash />
-                                            <Header />
-                                            <Navigation extraPages={importedModules.map((i) => i.name)} />
-                                            <ErrorDialog isOpen={errorDialogOpen} close={errorDialogAction} />
+                                            <ReactQueryDevtools initialIsOpen={false} position={"bottom-right"} />
+                                            <div>
+                                                <Flash />
+                                                <Header />
+                                                <Navigation extraPages={importedModules.map((i) => i.name)} />
+                                                <ErrorDialog isOpen={errorDialogOpen} close={errorDialogAction} />
+                                            </div>
+                                            <Switch>
+                                                <Route exact path="/authorize" render={() => <Redirect to="/" />} />
+                                                <Route exact path="/" render={() => <Redirect to="/processes" />} />
+                                                <ProtectedRoute
+                                                    path="/new-process"
+                                                    render={(props) => (
+                                                        <NewProcess
+                                                            preselectedInput={getQueryParameters(props.location.search)}
+                                                        />
+                                                    )}
+                                                />
+                                                <ProtectedRoute
+                                                    path="/modify-subscription"
+                                                    render={(props) => (
+                                                        <ModifySubscription
+                                                            workflowName={getParameterByName(
+                                                                "workflow",
+                                                                props.location.search
+                                                            )}
+                                                            subscriptionId={getParameterByName(
+                                                                "subscription",
+
+                                                                props.location.search
+                                                            )}
+                                                        />
+                                                    )}
+                                                />
+                                                <ProtectedRoute
+                                                    path="/terminate-subscription"
+                                                    render={(props) => (
+                                                        <TerminateSubscription
+                                                            subscriptionId={getParameterByName(
+                                                                "subscription",
+
+                                                                props.location.search
+                                                            )}
+                                                        />
+                                                    )}
+                                                />
+                                                <Route
+                                                    path="/process/:id"
+                                                    render={(props) => (
+                                                        <Redirect to={`/processes/${props.match.params.id}`} />
+                                                    )}
+                                                />
+                                                <Route
+                                                    path="/processes/:id"
+                                                    render={(props) => <ProcessDetail {...props} />}
+                                                />
+                                                <ProtectedRoute path="/processes" render={(props) => <Processes />} />
+                                                <Route
+                                                    path="/subscription/:id"
+                                                    render={(props) => (
+                                                        <Redirect to={`/subscriptions/${props.match.params.id}`} />
+                                                    )}
+                                                />
+                                                {!disabledRoutes.includes("/subscriptions/:id") && (
+                                                    <Route
+                                                        path="/subscriptions/:id"
+                                                        render={(props) => <SubscriptionDetailPage {...props} />}
+                                                    />
+                                                )}
+                                                {!disabledRoutes.includes("/subscriptions") && (
+                                                    <Route
+                                                        path="/subscriptions"
+                                                        render={(props) => <SubscriptionsPage {...props} />}
+                                                    />
+                                                )}
+                                                {!disabledRoutes.includes("/metadata") && (
+                                                    <Route
+                                                        exact
+                                                        path="/metadata"
+                                                        render={() => <Redirect to="/metadata/products" />}
+                                                    />
+                                                )}
+                                                <ProtectedRoute
+                                                    path="/metadata/product-block/:id"
+                                                    render={(props) => <ProductBlock {...props} />}
+                                                />
+                                                <ProtectedRoute
+                                                    path="/metadata/product/:id"
+                                                    render={(props) => <ProductPage {...props} />}
+                                                />
+                                                <ProtectedRoute
+                                                    path="/metadata/:type"
+                                                    render={(props) => (
+                                                        <MetaData selectedTab={props.match.params.type} {...props} />
+                                                    )}
+                                                />
+                                                {!disabledRoutes.includes("/metadata") && (
+                                                    <ProtectedRoute path="/settings" render={() => <Settings />} />
+                                                )}
+
+                                                {!isEmpty(importedModules) &&
+                                                    importedModules.map(({ path, name, Component }) => (
+                                                        <Route key={path} exact path={`/${name}`} component={Component} />
+                                                    ))}
+
+                                                <ProtectedRoute path="/new-task" render={() => <NewTask />} />
+
+                                                <ProtectedRoute path="/tasks" render={() => <Tasks />} />
+                                                <Route path="/task/:id" render={(props) => <ProcessDetail {...props} />} />
+                                                <Route path="/not-allowed" render={() => <NotAllowed />} />
+                                                <Route path="/error" render={(props) => <ServerError {...props} />} />
+                                                <Route path="/styleguide" render={(props) => <StyleGuide {...props} />} />
+                                                <Route component={NotFound} />
+                                            </Switch>
                                         </div>
-                                        <Switch>
-                                            <Route exact path="/authorize" render={() => <Redirect to="/" />} />
-                                            <Route exact path="/" render={() => <Redirect to="/processes" />} />
-                                            <ProtectedRoute
-                                                path="/new-process"
-                                                render={(props) => (
-                                                    <NewProcess
-                                                        preselectedInput={getQueryParameters(props.location.search)}
-                                                    />
-                                                )}
-                                            />
-                                            <ProtectedRoute
-                                                path="/modify-subscription"
-                                                render={(props) => (
-                                                    <ModifySubscription
-                                                        workflowName={getParameterByName(
-                                                            "workflow",
-                                                            props.location.search
-                                                        )}
-                                                        subscriptionId={getParameterByName(
-                                                            "subscription",
-
-                                                            props.location.search
-                                                        )}
-                                                    />
-                                                )}
-                                            />
-                                            <ProtectedRoute
-                                                path="/terminate-subscription"
-                                                render={(props) => (
-                                                    <TerminateSubscription
-                                                        subscriptionId={getParameterByName(
-                                                            "subscription",
-
-                                                            props.location.search
-                                                        )}
-                                                    />
-                                                )}
-                                            />
-                                            <Route
-                                                path="/process/:id"
-                                                render={(props) => (
-                                                    <Redirect to={`/processes/${props.match.params.id}`} />
-                                                )}
-                                            />
-                                            <Route
-                                                path="/processes/:id"
-                                                render={(props) => <ProcessDetail {...props} />}
-                                            />
-                                            <ProtectedRoute path="/processes" render={(props) => <Processes />} />
-                                            <Route
-                                                path="/subscription/:id"
-                                                render={(props) => (
-                                                    <Redirect to={`/subscriptions/${props.match.params.id}`} />
-                                                )}
-                                            />
-                                            {!disabledRoutes.includes("/subscriptions/:id") && (
-                                                <Route
-                                                    path="/subscriptions/:id"
-                                                    render={(props) => <SubscriptionDetailPage {...props} />}
-                                                />
-                                            )}
-                                            {!disabledRoutes.includes("/subscriptions") && (
-                                                <Route
-                                                    path="/subscriptions"
-                                                    render={(props) => <SubscriptionsPage {...props} />}
-                                                />
-                                            )}
-                                            {!disabledRoutes.includes("/metadata") && (
-                                                <Route
-                                                    exact
-                                                    path="/metadata"
-                                                    render={() => <Redirect to="/metadata/products" />}
-                                                />
-                                            )}
-                                            <ProtectedRoute
-                                                path="/metadata/product-block/:id"
-                                                render={(props) => <ProductBlock {...props} />}
-                                            />
-                                            <ProtectedRoute
-                                                path="/metadata/product/:id"
-                                                render={(props) => <ProductPage {...props} />}
-                                            />
-                                            <ProtectedRoute
-                                                path="/metadata/:type"
-                                                render={(props) => (
-                                                    <MetaData selectedTab={props.match.params.type} {...props} />
-                                                )}
-                                            />
-                                            {!disabledRoutes.includes("/metadata") && (
-                                                <ProtectedRoute path="/settings" render={() => <Settings />} />
-                                            )}
-
-                                            {!isEmpty(importedModules) &&
-                                                importedModules.map(({ path, name, Component }) => (
-                                                    <Route key={path} exact path={`/${name}`} component={Component} />
-                                                ))}
-
-                                            <ProtectedRoute path="/new-task" render={() => <NewTask />} />
-
-                                            <ProtectedRoute path="/tasks" render={() => <Tasks />} />
-                                            <Route path="/task/:id" render={(props) => <ProcessDetail {...props} />} />
-                                            <Route path="/not-allowed" render={() => <NotAllowed />} />
-                                            <Route path="/error" render={(props) => <ServerError {...props} />} />
-                                            <Route path="/styleguide" render={(props) => <StyleGuide {...props} />} />
-                                            <Route component={NotFound} />
-                                        </Switch>
-                                    </div>
+                                    </GlobalContextProviders>
                                 </RawIntlProvider>
-                            </RunningProcessesContextWrapper>
                         </ApplicationContext.Provider>
                     </QueryParamProvider>
                 </Router>

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -19,6 +19,7 @@ import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiPage, EuiPageBody, EuiPanel, E
 import UserInputFormWizard from "components/inputForms/UserInputFormWizard";
 import ConfirmationDialog from "components/modals/ConfirmationDialog";
 import ProcessStateDetails from "components/ProcessStateDetails";
+import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 import React from "react";
 import { FormattedMessage, WrappedComponentProps, injectIntl } from "react-intl";
 import { RouteComponentProps } from "react-router-dom";
@@ -31,7 +32,6 @@ import { CommaSeparatedNumericArrayParam } from "utils/QueryParameters";
 import { InputForm, ProcessSubscription, ProcessWithDetails, Product, Step, WsProcessV2 } from "utils/types";
 import { stop } from "utils/Utils";
 import { actionOptions } from "validations/Processes";
-import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 
 const queryConfig: QueryParamConfigMap = { collapsed: CommaSeparatedNumericArrayParam, scrollToStep: NumberParam };
 

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -31,7 +31,7 @@ import { CommaSeparatedNumericArrayParam } from "utils/QueryParameters";
 import { InputForm, ProcessSubscription, ProcessWithDetails, Product, Step, WsProcessV2 } from "utils/types";
 import { stop } from "utils/Utils";
 import { actionOptions } from "validations/Processes";
-import RunningProcessesContext from "websocketService/useRunningProcesses/RunningProcessesContext";
+import RunningProcessesContext from "contextProviders/runningProcessesProvider";
 
 const queryConfig: QueryParamConfigMap = { collapsed: CommaSeparatedNumericArrayParam, scrollToStep: NumberParam };
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -26,11 +26,11 @@ import {
     EuiSelect,
     EuiSpacer,
 } from "@elastic/eui";
-import React, { FunctionComponent, useCallback, useContext, useEffect, useState } from "react";
+import EngineSettingsContext from "contextProviders/engineSettingsProvider";
+import { FunctionComponent, useContext, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import ApplicationContext from "utils/ApplicationContext";
 import { setFlash } from "utils/Flash";
-import { EngineStatus } from "utils/types";
 
 enum Cache {
     ims = "ims",
@@ -44,22 +44,8 @@ interface IProps {}
 export const Settings: FunctionComponent = (props: IProps) => {
     const intl = useIntl();
     const [cache, setCache] = useState<Cache>(Cache.ims);
-    const [engineStatus, setEngineStatus] = useState<EngineStatus>();
     const { apiClient } = useContext(ApplicationContext);
-
-    const getEngineStatus = useCallback(() => {
-        apiClient.getGlobalStatus().then((newEngineStatus) => {
-            setEngineStatus(newEngineStatus);
-        });
-    }, [setEngineStatus, apiClient]);
-
-    useEffect(() => {
-        getEngineStatus();
-        const interval = window.setInterval(getEngineStatus, 3000);
-        return () => {
-            clearInterval(interval);
-        };
-    }, [getEngineStatus]);
+    const { engineStatus } = useContext(EngineSettingsContext);
 
     const lockEngine = (isLocked: boolean) => {
         apiClient.setGlobalStatus(isLocked).then(() => {


### PR DESCRIPTION
- add contextProviders folder.
- add globalContextProviders to easily add global providers without nesting directly in app.tsx.
- add context provider for engine settings.
- replace places that need engine settings to use engineSettingsProvider.
- change the engine settings banner in header to a component `engineStatusBanner`.
- move RunningProcessesContext to contextProviders folder.