### PR TITLE
do not show customer name if not resolved

### DIFF
--- a/src/components/subscriptionDetail/SubscriptionDetails.tsx
+++ b/src/components/subscriptionDetail/SubscriptionDetails.tsx
@@ -159,7 +159,7 @@ export default function SubscriptionDetails({ subscription, className = "", subs
                         {!subscription.insync && renderFailedTask(subscriptionProcesses)}
                     </td>
                 </tr>
-                {customer_name && (
+                {customer_name && customer_name !== subscription.customer_id && (
                     <tr>
                         <td id="subscriptions-customer-name-k">
                             <FormattedMessage id="subscriptions.customer_name" />


### PR DESCRIPTION
see issue 20.
If unresolved (because CRM might be unavailable) the UUID was shown. 
The field is now hidden if unresolved (i.e. equal to the UUID).