### PR TITLE
Change components that use ConfirmationDialog to use ConfirmationDialogContext provider

### DIFF
--- a/src/components/EditProduct.tsx
+++ b/src/components/EditProduct.tsx
@@ -54,7 +54,7 @@ interface IState {
     statuses: string[];
     duplicateName: boolean;
     showConfirmDialog: ShowConfirmDialogType;
-    cancelConfirmDialog: () => void;
+    closeConfirmDialog: () => void;
 }
 
 class EditProduct extends React.Component<IProps, IState> {
@@ -72,7 +72,7 @@ class EditProduct extends React.Component<IProps, IState> {
         statuses: [],
         duplicateName: false,
         showConfirmDialog: () => {},
-        cancelConfirmDialog: () => {},
+        closeConfirmDialog: () => {},
     };
 
     componentDidMount() {
@@ -117,7 +117,7 @@ class EditProduct extends React.Component<IProps, IState> {
                 })
                 .catch((err: any) => {
                     if (err.response && err.response.status === 400) {
-                        this.state.cancelConfirmDialog();
+                        this.state.closeConfirmDialog();
                         if (err.response.data) {
                             setFlash(err.response.data.error);
                         }
@@ -219,8 +219,8 @@ class EditProduct extends React.Component<IProps, IState> {
         this.setState({ product: product });
     };
 
-    addConfirmDialogActions = ({ showConfirmDialog, cancelConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog, cancelConfirmDialog });
+    addConfirmDialogActions = ({ showConfirmDialog, closeConfirmDialog }: ConfirmDialogActions) => {
+        this.setState({ showConfirmDialog, closeConfirmDialog });
         return <></>;
     };
 

--- a/src/components/EditProduct.tsx
+++ b/src/components/EditProduct.tsx
@@ -220,7 +220,9 @@ class EditProduct extends React.Component<IProps, IState> {
     };
 
     addConfirmDialogActions = ({ showConfirmDialog, closeConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog, closeConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog, closeConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/components/EditProduct.tsx
+++ b/src/components/EditProduct.tsx
@@ -17,7 +17,10 @@ import "components/Product.scss";
 import "./Product.scss";
 
 import { EuiButton } from "@elastic/eui";
-import ConfirmationDialog from "components/modals/ConfirmationDialog";
+import ConfirmationDialogContext, {
+    ConfirmDialogActions,
+    ShowConfirmDialogType,
+} from "contextProviders/ConfirmationDialogProvider";
 import { isDate } from "date-fns";
 import { formDate, formInput, formSelect } from "forms/Builder";
 import React from "react";
@@ -37,11 +40,6 @@ interface MatchParams {
 interface IProps extends Partial<RouteComponentProps<MatchParams>>, WrappedComponentProps {}
 
 interface IState {
-    confirmationDialogOpen: boolean;
-    confirmationDialogAction: () => void;
-    cancelDialogAction: () => void;
-    confirmationDialogQuestion: string;
-    leavePage: boolean;
     errors: Partial<Record<keyof ProductData, boolean>>;
     required: (keyof ProductData)[];
     initial: boolean;
@@ -55,15 +53,12 @@ interface IState {
     types: string[];
     statuses: string[];
     duplicateName: boolean;
+    showConfirmDialog: ShowConfirmDialogType;
+    cancelConfirmDialog: () => void;
 }
 
 class EditProduct extends React.Component<IProps, IState> {
     state: IState = {
-        confirmationDialogOpen: false,
-        confirmationDialogAction: () => this.setState({ confirmationDialogOpen: false }),
-        cancelDialogAction: () => this.context.redirect("/metadata/products"),
-        confirmationDialogQuestion: "",
-        leavePage: true,
         errors: {},
         required: ["name", "description", "status", "product_type", "tag"],
         initial: true,
@@ -76,6 +71,8 @@ class EditProduct extends React.Component<IProps, IState> {
         types: [],
         statuses: [],
         duplicateName: false,
+        showConfirmDialog: () => {},
+        cancelConfirmDialog: () => {},
     };
 
     componentDidMount() {
@@ -93,13 +90,14 @@ class EditProduct extends React.Component<IProps, IState> {
 
     cancel = (e: React.MouseEvent<HTMLElement>) => {
         stop(e);
-        this.setState({
-            confirmationDialogOpen: true,
+        this.state.showConfirmDialog({
+            question: "",
+            confirmAction: () => {},
+            cancelAction: () => this.context.redirect("/metadata/products"),
             leavePage: true,
-            confirmationDialogAction: () => this.setState({ confirmationDialogOpen: false }),
-            cancelDialogAction: () => this.context.redirect("/metadata/products"),
         });
     };
+
     handleDeleteProduct = (e: React.MouseEvent<HTMLElement>) => {
         stop(e);
         const { product } = this.state;
@@ -108,7 +106,7 @@ class EditProduct extends React.Component<IProps, IState> {
             { id: "metadata.deleteConfirmation" },
             { type: "Product", name: product!.name }
         );
-        const action = () =>
+        const confirmAction = () =>
             this.context.apiClient
                 .deleteProduct(product!.product_id)
                 .then(() => {
@@ -119,7 +117,7 @@ class EditProduct extends React.Component<IProps, IState> {
                 })
                 .catch((err: any) => {
                     if (err.response && err.response.status === 400) {
-                        this.setState({ confirmationDialogOpen: false });
+                        this.state.cancelConfirmDialog();
                         if (err.response.data) {
                             setFlash(err.response.data.error);
                         }
@@ -127,13 +125,8 @@ class EditProduct extends React.Component<IProps, IState> {
                         throw err;
                     }
                 });
-        this.setState({
-            confirmationDialogOpen: true,
-            confirmationDialogQuestion: question,
-            leavePage: false,
-            confirmationDialogAction: action,
-            cancelDialogAction: () => this.setState({ confirmationDialogOpen: false }),
-        });
+
+        this.state.showConfirmDialog({ question, confirmAction });
     };
     submit = (e: React.MouseEvent<HTMLElement>) => {
         stop(e);
@@ -226,18 +219,13 @@ class EditProduct extends React.Component<IProps, IState> {
         this.setState({ product: product });
     };
 
+    addConfirmDialogActions = ({ showConfirmDialog, cancelConfirmDialog }: ConfirmDialogActions) => {
+        this.setState({ showConfirmDialog, cancelConfirmDialog });
+        return <></>;
+    };
+
     render() {
-        const {
-            confirmationDialogOpen,
-            confirmationDialogAction,
-            cancelDialogAction,
-            product,
-            leavePage,
-            duplicateName,
-            initial,
-            confirmationDialogQuestion,
-            statuses,
-        } = this.state;
+        const { product, duplicateName, initial, statuses } = this.state;
         const { intl } = this.props;
         if (!product) {
             return null;
@@ -250,13 +238,9 @@ class EditProduct extends React.Component<IProps, IState> {
             : new Date(product.end_date * 1000);
         return (
             <div className="mod-product">
-                <ConfirmationDialog
-                    isOpen={confirmationDialogOpen}
-                    cancel={cancelDialogAction}
-                    confirm={confirmationDialogAction}
-                    leavePage={leavePage}
-                    question={confirmationDialogQuestion}
-                />
+                <ConfirmationDialogContext.Consumer>
+                    {(cdc) => this.addConfirmDialogActions(cdc)}
+                </ConfirmationDialogContext.Consumer>
                 <section className="card">
                     {formInput(
                         "metadata.products.name",

--- a/src/components/ProductBlock.tsx
+++ b/src/components/ProductBlock.tsx
@@ -227,7 +227,9 @@ class ProductBlock extends React.Component<IProps, IState> {
     };
 
     addConfirmDialogActions = ({ showConfirmDialog, closeConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog, closeConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog, closeConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/components/ProductBlock.tsx
+++ b/src/components/ProductBlock.tsx
@@ -54,7 +54,7 @@ interface IState {
     resourceTypes: ResourceType[];
     productBlocks: iProductBlock[];
     showConfirmDialog: ShowConfirmDialogType;
-    cancelConfirmDialog: () => void;
+    closeConfirmDialog: () => void;
 }
 
 class ProductBlock extends React.Component<IProps, IState> {
@@ -68,7 +68,7 @@ class ProductBlock extends React.Component<IProps, IState> {
         resourceTypes: [],
         productBlocks: [],
         showConfirmDialog: () => {},
-        cancelConfirmDialog: () => {},
+        closeConfirmDialog: () => {},
     };
 
     componentDidMount() {
@@ -115,7 +115,7 @@ class ProductBlock extends React.Component<IProps, IState> {
                 })
                 .catch((err: any) => {
                     if (err.response && err.response.status === 400) {
-                        this.state.cancelConfirmDialog();
+                        this.state.closeConfirmDialog();
                         if (err.response.data) {
                             setFlash(err.response.data.error);
                         }
@@ -226,8 +226,8 @@ class ProductBlock extends React.Component<IProps, IState> {
         this.setState({ productBlock: productBlock });
     };
 
-    addConfirmDialogActions = ({ showConfirmDialog, cancelConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog, cancelConfirmDialog });
+    addConfirmDialogActions = ({ showConfirmDialog, closeConfirmDialog }: ConfirmDialogActions) => {
+        this.setState({ showConfirmDialog, closeConfirmDialog });
         return <></>;
     };
 

--- a/src/components/ProductBlocks.tsx
+++ b/src/components/ProductBlocks.tsx
@@ -21,7 +21,10 @@ import {
     EuiPageContentHeader,
     EuiSpacer,
 } from "@elastic/eui";
-import ConfirmationDialog from "components/modals/ConfirmationDialog";
+import ConfirmationDialogContext, {
+    ConfirmDialogActions,
+    ShowConfirmDialogType,
+} from "contextProviders/ConfirmationDialogProvider";
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import ApplicationContext from "utils/ApplicationContext";
@@ -34,11 +37,7 @@ interface IState {
     productBlocks: ProductBlock[];
     productBlocksLoaded: boolean;
     isLoading: boolean;
-    confirmationDialogOpen: boolean;
-    confirmationDialogAction: () => void;
-    confirm: () => void;
-    confirmationDialogQuestion: string;
-    leavePage: boolean;
+    showConfirmDialog: ShowConfirmDialogType;
 }
 
 class ProductBlocks extends React.Component<WrappedComponentProps, IState> {
@@ -48,11 +47,7 @@ class ProductBlocks extends React.Component<WrappedComponentProps, IState> {
         productBlocks: [],
         productBlocksLoaded: true,
         isLoading: false,
-        confirmationDialogOpen: false,
-        confirmationDialogAction: () => this,
-        confirm: () => this,
-        confirmationDialogQuestion: "",
-        leavePage: true,
+        showConfirmDialog: () => {},
     };
 
     componentDidMount() {
@@ -60,8 +55,6 @@ class ProductBlocks extends React.Component<WrappedComponentProps, IState> {
             this.setState({ productBlocks: productBlocks, productBlocksLoaded: false });
         });
     }
-
-    cancelConfirmation = () => this.setState({ confirmationDialogOpen: false });
 
     handleDeleteProductBlock = (productBlock: ProductBlock) => (e: React.MouseEvent<HTMLButtonElement>) => {
         stop(e);
@@ -96,24 +89,19 @@ class ProductBlocks extends React.Component<WrappedComponentProps, IState> {
         );
     };
 
-    confirmation = (question: string, action: () => void) =>
-        this.setState({
-            confirmationDialogOpen: true,
-            confirmationDialogQuestion: question,
-            confirmationDialogAction: () => {
-                this.cancelConfirmation();
-                action();
-            },
+    confirmation = (question: string, confirmAction: () => void) =>
+        this.state.showConfirmDialog({
+            question,
+            confirmAction,
         });
 
+    addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
+        this.setState({ showConfirmDialog });
+        return <></>;
+    };
+
     render() {
-        const {
-            productBlocks,
-            productBlocksLoaded,
-            confirmationDialogOpen,
-            confirmationDialogAction,
-            confirmationDialogQuestion,
-        } = this.state;
+        const { productBlocks, productBlocksLoaded } = this.state;
 
         const search = {
             box: {
@@ -222,13 +210,10 @@ class ProductBlocks extends React.Component<WrappedComponentProps, IState> {
 
         return (
             <EuiPageContent>
+                <ConfirmationDialogContext.Consumer>
+                    {(cdc) => this.addConfirmDialogActions(cdc)}
+                </ConfirmationDialogContext.Consumer>
                 <EuiPageContentHeader>
-                    <ConfirmationDialog
-                        isOpen={confirmationDialogOpen}
-                        cancel={this.cancelConfirmation}
-                        confirm={confirmationDialogAction}
-                        question={confirmationDialogQuestion}
-                    />
                     <EuiSpacer size="l" />
                     <EuiInMemoryTable
                         items={productBlocks}

--- a/src/components/ProductBlocks.tsx
+++ b/src/components/ProductBlocks.tsx
@@ -96,7 +96,9 @@ class ProductBlocks extends React.Component<WrappedComponentProps, IState> {
         });
 
     addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -38,7 +38,7 @@ function Products() {
     const [products, setProducts] = useState<Product[]>([]);
     const [productsLoaded, setProductsLoaded] = useState(true);
     const [reload, setReload] = useState(false);
-    const { showConfirmDialog, cancelConfirmDialog } = useContext(ConfirmationDialogContext);
+    const { showConfirmDialog, closeConfirmDialog } = useContext(ConfirmationDialogContext);
     const history = useHistory();
 
     useEffect(() => {
@@ -67,7 +67,7 @@ function Products() {
                     throw err;
                 }
             });
-        cancelConfirmDialog();
+        closeConfirmDialog();
     };
 
     const handleDeleteProduct = (product: Product) => (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/SubscriptionValidation.tsx
+++ b/src/components/SubscriptionValidation.tsx
@@ -16,7 +16,10 @@
 import "components/SubscriptionValidation.scss";
 
 import CheckBox from "components/CheckBox";
-import ConfirmationDialog from "components/modals/ConfirmationDialog";
+import ConfirmationDialogContext, {
+    ConfirmDialogActions,
+    ShowConfirmDialogType,
+} from "contextProviders/ConfirmationDialogProvider";
 import React from "react";
 import { FormattedMessage, WrappedComponentProps, injectIntl } from "react-intl";
 import ApplicationContext from "utils/ApplicationContext";
@@ -43,19 +46,13 @@ interface IProps extends WrappedComponentProps {
 interface IState {
     sorted: SortOption;
     subscriptions?: SubscriptionWithDetails[];
-    confirmationDialogOpen: boolean;
-    confirmationDialogAction: () => void;
-    confirm: () => void;
-    confirmationDialogQuestion: string;
+    showConfirmDialog: ShowConfirmDialogType;
 }
 
 class SubscriptionValidation extends React.Component<IProps, IState> {
     state: IState = {
         sorted: { name: "status", descending: false },
-        confirmationDialogOpen: false,
-        confirmationDialogAction: () => this,
-        confirm: () => this,
-        confirmationDialogQuestion: "",
+        showConfirmDialog: () => {},
     };
 
     componentDidUpdate(prevProps: IProps) {
@@ -101,16 +98,10 @@ class SubscriptionValidation extends React.Component<IProps, IState> {
         return <i />;
     };
 
-    cancelConfirmation = () => this.setState({ confirmationDialogOpen: false });
-
-    confirmation = (question: string, action: () => void) =>
-        this.setState({
-            confirmationDialogOpen: true,
-            confirmationDialogQuestion: question,
-            confirmationDialogAction: () => {
-                this.cancelConfirmation();
-                action();
-            },
+    confirmation = (question: string, confirmAction: () => void) =>
+        this.state.showConfirmDialog({
+            question,
+            confirmAction,
         });
 
     handleDeleteSubscription = (subscription: SubscriptionWithDetails) => (e: React.MouseEvent<HTMLElement>) => {
@@ -239,23 +230,19 @@ class SubscriptionValidation extends React.Component<IProps, IState> {
         );
     }
 
+    addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
+        this.setState({ showConfirmDialog });
+        return <></>;
+    };
+
     render() {
-        const {
-            subscriptions,
-            sorted,
-            confirmationDialogOpen,
-            confirmationDialogAction,
-            confirmationDialogQuestion,
-        } = this.state;
+        const { subscriptions, sorted } = this.state;
         const { workflow } = this.props;
         return (
             <section className="subscription-validation">
-                <ConfirmationDialog
-                    isOpen={confirmationDialogOpen}
-                    cancel={this.cancelConfirmation}
-                    confirm={confirmationDialogAction}
-                    question={confirmationDialogQuestion}
-                />
+                <ConfirmationDialogContext.Consumer>
+                    {(cdc) => this.addConfirmDialogActions(cdc)}
+                </ConfirmationDialogContext.Consumer>
                 <h3>
                     <FormattedMessage id="validations.workflow_key" values={{ workflow: workflow }} />
                 </h3>

--- a/src/components/SubscriptionValidation.tsx
+++ b/src/components/SubscriptionValidation.tsx
@@ -231,7 +231,9 @@ class SubscriptionValidation extends React.Component<IProps, IState> {
     }
 
     addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/components/inputForms/UserInputForm.tsx
+++ b/src/components/inputForms/UserInputForm.tsx
@@ -299,11 +299,12 @@ class UserInputForm extends React.Component<IProps, IState> {
         hasNext: false,
     };
 
-    cancel = (e: React.FormEvent) => {
+    openDialog = (e: React.FormEvent) => {
         stop(e);
         this.state.showConfirmDialog({
             question: "",
             confirmAction: () => {},
+            cancelAction: this.props.cancel,
             leavePage: true,
         });
     };
@@ -364,7 +365,7 @@ class UserInputForm extends React.Component<IProps, IState> {
             </EuiButton>
         ) : (
             <EuiFlexItem>
-                <EuiButton id="button-cancel-form-submit" color="warning" onClick={this.cancel}>
+                <EuiButton id="button-cancel-form-submit" color="warning" onClick={this.openDialog}>
                     <FormattedMessage id="process.cancel" />
                 </EuiButton>
             </EuiFlexItem>
@@ -403,7 +404,9 @@ class UserInputForm extends React.Component<IProps, IState> {
     };
 
     addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/components/inputForms/UserInputForm.tsx
+++ b/src/components/inputForms/UserInputForm.tsx
@@ -16,8 +16,11 @@
 import "components/inputForms/UserInputForm.scss";
 
 import { EuiButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
-import ConfirmationDialog from "components/modals/ConfirmationDialog";
 import { SubscriptionsContextProvider } from "components/subscriptionContext";
+import ConfirmationDialogContext, {
+    ConfirmDialogActions,
+    ShowConfirmDialogType,
+} from "contextProviders/ConfirmationDialogProvider";
 import { autoFieldFunction } from "custom/uniforms/AutoFieldLoader";
 import invariant from "invariant";
 import { JSONSchema6 } from "json-schema";
@@ -49,10 +52,10 @@ interface IProps extends RouteComponentProps {
 }
 
 interface IState {
-    confirmationDialogOpen: boolean;
     nrOfValidationErrors: number;
     processing: boolean;
     rootErrors: string[];
+    showConfirmDialog: ShowConfirmDialogType;
 }
 
 declare module "uniforms" {
@@ -284,10 +287,10 @@ function fillPreselection(form: JSONSchema6, query: string) {
 class UserInputForm extends React.Component<IProps, IState> {
     context!: React.ContextType<typeof ApplicationContext>;
     state: IState = {
-        confirmationDialogOpen: false,
         processing: false,
         nrOfValidationErrors: 0,
         rootErrors: [],
+        showConfirmDialog: () => {},
     };
 
     public static defaultProps = {
@@ -298,7 +301,11 @@ class UserInputForm extends React.Component<IProps, IState> {
 
     cancel = (e: React.FormEvent) => {
         stop(e);
-        this.setState({ confirmationDialogOpen: true });
+        this.state.showConfirmDialog({
+            question: "",
+            confirmAction: () => {},
+            leavePage: true,
+        });
     };
 
     submit = async (userInput: any = {}) => {
@@ -395,9 +402,14 @@ class UserInputForm extends React.Component<IProps, IState> {
         );
     };
 
+    addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
+        this.setState({ showConfirmDialog });
+        return <></>;
+    };
+
     render() {
-        const { confirmationDialogOpen, nrOfValidationErrors, rootErrors } = this.state;
-        const { cancel, stepUserInput, userInput, location } = this.props;
+        const { nrOfValidationErrors, rootErrors } = this.state;
+        const { stepUserInput, userInput, location } = this.props;
         const prefilledForm = fillPreselection(stepUserInput, location.search);
         const bridge = new CustomTitleJSONSchemaBridge(prefilledForm, () => {});
 
@@ -405,12 +417,9 @@ class UserInputForm extends React.Component<IProps, IState> {
 
         return (
             <div className="user-input-form">
-                <ConfirmationDialog
-                    isOpen={confirmationDialogOpen}
-                    cancel={cancel}
-                    confirm={() => this.setState({ confirmationDialogOpen: false })}
-                    leavePage={true}
-                />
+                <ConfirmationDialogContext.Consumer>
+                    {(cdc) => this.addConfirmDialogActions(cdc)}
+                </ConfirmationDialogContext.Consumer>
                 <section className="form-fieldset">
                     {stepUserInput.title && stepUserInput.title !== "unknown" && <h3>{stepUserInput.title}</h3>}
                     <SubscriptionsContextProvider>

--- a/src/components/subscriptionDetail/Renderers.tsx
+++ b/src/components/subscriptionDetail/Renderers.tsx
@@ -34,33 +34,33 @@ export function RenderActions({
 }) {
     const intl = useIntl();
     const { allowed, organisations, redirect, theme } = useContext(ApplicationContext);
-    const { showConfirmDialog: confirmation } = useContext(ConfirmationDialogContext);
+    const { showConfirmDialog } = useContext(ConfirmationDialogContext);
 
-    if (!confirmation) {
+    if (!showConfirmDialog) {
         return null;
     }
 
     const terminate = (e: React.MouseEvent<HTMLElement>) => {
         stop(e);
 
-        confirmation(
-            intl.formatMessage(
+        showConfirmDialog({
+            question: intl.formatMessage(
                 { id: "subscription.terminateConfirmation" },
                 {
                     name: subscription.product.name,
                     customer: organisationNameByUuid(subscription.customer_id, organisations),
                 }
             ),
-            () => redirect(`/terminate-subscription?subscription=${subscription.subscription_id}`)
-        );
+            confirmAction: () => redirect(`/terminate-subscription?subscription=${subscription.subscription_id}`),
+        });
     };
 
     const modify = (workflow_name: string) => (e: React.MouseEvent<HTMLElement>) => {
         stop(e);
 
         const change = intl.formatMessage({ id: `workflow.${workflow_name}` }).toLowerCase();
-        confirmation(
-            intl.formatMessage(
+        showConfirmDialog({
+            question: intl.formatMessage(
                 { id: "subscription.modifyConfirmation" },
                 {
                     name: subscription.product.name,
@@ -68,9 +68,9 @@ export function RenderActions({
                     change: change,
                 }
             ),
-            () =>
-                redirect(`/modify-subscription?workflow=${workflow_name}&subscription=${subscription.subscription_id}`)
-        );
+            confirmAction: () =>
+                redirect(`/modify-subscription?workflow=${workflow_name}&subscription=${subscription.subscription_id}`),
+        });
     };
 
     return (

--- a/src/contextProviders/ConfirmationDialogProvider/index.tsx
+++ b/src/contextProviders/ConfirmationDialogProvider/index.tsx
@@ -3,8 +3,8 @@ import { createContext, useState } from "react";
 
 export interface ShowConfirmDialog {
     question: string;
-    confirmAction: (e: React.MouseEvent) => void;
-    cancelAction?: (e: React.MouseEvent) => void;
+    confirmAction: (e: React.MouseEvent<HTMLButtonElement>) => void;
+    cancelAction?: (e: React.MouseEvent<HTMLButtonElement>) => void;
     leavePage?: boolean;
     isError?: boolean;
 }
@@ -34,10 +34,11 @@ export function ConfirmationDialogContextWrapper({ children }: any) {
     const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
     const [state, setState] = useState({
         confirmationDialogQuestion: "",
-        confirmDialogAction: (e: React.MouseEvent, cancelConfirm: boolean = false) => {},
+        confirmDialogAction: (e: React.MouseEvent<HTMLButtonElement>, cancelConfirm: boolean = false) => {},
         leavePage: false,
         isError: false,
     });
+
     const closeConfirmDialog = () => setConfirmationDialogOpen(false);
 
     const showConfirmDialog = ({ question, confirmAction, cancelAction, leavePage, isError }: ShowConfirmDialog) => {
@@ -46,7 +47,7 @@ export function ConfirmationDialogContextWrapper({ children }: any) {
             confirmationDialogQuestion: question,
             leavePage: !!leavePage,
             isError: !!isError,
-            confirmDialogAction: (e: React.MouseEvent, cancelConfirm: boolean = false) => {
+            confirmDialogAction: (e: React.MouseEvent<HTMLButtonElement>, cancelConfirm: boolean = false) => {
                 closeConfirmDialog();
 
                 if (!cancelConfirm) {

--- a/src/contextProviders/ConfirmationDialogProvider/index.tsx
+++ b/src/contextProviders/ConfirmationDialogProvider/index.tsx
@@ -19,51 +19,53 @@ export type ShowConfirmDialogType = ({
 
 export interface ConfirmDialogActions {
     showConfirmDialog: ShowConfirmDialogType;
-    cancelConfirmDialog: () => void;
+    closeConfirmDialog: () => void;
 }
 
 const ConfirmationDialogContext = createContext<ConfirmDialogActions>({
     showConfirmDialog: () => {},
-    cancelConfirmDialog: () => {},
+    closeConfirmDialog: () => {},
 });
 
 export const ConfirmationDialogProvider = ConfirmationDialogContext.Provider;
 export default ConfirmationDialogContext;
 
 export function ConfirmationDialogContextWrapper({ children }: any) {
-    const [confirmationDialogOpen, setCnfirmationDialogOpen] = useState(false);
+    const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
     const [state, setState] = useState({
         confirmationDialogQuestion: "",
-        confirmationDialogAction: (e: React.MouseEvent) => {},
-        cancelConfirmDialogAction: (e: React.MouseEvent) => {},
+        confirmDialogAction: (e: React.MouseEvent, cancelConfirm: boolean = false) => {},
         leavePage: false,
         isError: false,
     });
-    const cancelConfirmDialog = () => setCnfirmationDialogOpen(false);
+    const closeConfirmDialog = () => setConfirmationDialogOpen(false);
 
     const showConfirmDialog = ({ question, confirmAction, cancelAction, leavePage, isError }: ShowConfirmDialog) => {
-        setCnfirmationDialogOpen(true);
+        setConfirmationDialogOpen(true);
         setState({
             confirmationDialogQuestion: question,
             leavePage: !!leavePage,
             isError: !!isError,
-            confirmationDialogAction: (e: React.MouseEvent) => {
-                cancelConfirmDialog();
-                confirmAction(e);
-            },
-            cancelConfirmDialogAction: (e: React.MouseEvent) => {
-                cancelConfirmDialog();
-                if (cancelAction) cancelAction(e);
+            confirmDialogAction: (e: React.MouseEvent, cancelConfirm: boolean = false) => {
+                closeConfirmDialog();
+
+                if (!cancelConfirm) {
+                    return confirmAction(e);
+                }
+
+                if (cancelAction) {
+                    return cancelAction(e);
+                }
             },
         });
     };
 
     return (
-        <ConfirmationDialogProvider value={{ showConfirmDialog, cancelConfirmDialog }}>
+        <ConfirmationDialogProvider value={{ showConfirmDialog, closeConfirmDialog }}>
             <ConfirmationDialog
                 isOpen={confirmationDialogOpen}
-                cancel={state.cancelConfirmDialogAction}
-                confirm={state.confirmationDialogAction}
+                cancel={(e) => state.confirmDialogAction(e, true)}
+                confirm={state.confirmDialogAction}
                 question={state.confirmationDialogQuestion}
                 leavePage={state.leavePage}
                 isError={state.isError}

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -444,7 +444,9 @@ class ProcessDetail extends React.PureComponent<IProps, IState> {
     );
 
     addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -61,7 +61,6 @@ interface IState {
     productName: string;
     customerName: string;
     showConfirmDialog: ShowConfirmDialogType;
-    cancelConfirmDialog: () => void;
 }
 
 class ProcessDetail extends React.PureComponent<IProps, IState> {
@@ -81,7 +80,6 @@ class ProcessDetail extends React.PureComponent<IProps, IState> {
             productName: "",
             customerName: "",
             showConfirmDialog: () => {},
-            cancelConfirmDialog: () => {},
         };
     }
 
@@ -445,8 +443,8 @@ class ProcessDetail extends React.PureComponent<IProps, IState> {
         </span>
     );
 
-    addConfirmDialogActions = ({ showConfirmDialog, cancelConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog, cancelConfirmDialog });
+    addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
+        this.setState({ showConfirmDialog });
         return <></>;
     };
 

--- a/src/pages/Processes.tsx
+++ b/src/pages/Processes.tsx
@@ -110,7 +110,9 @@ class Processes extends React.PureComponent<IProps, IState> {
     }
 
     addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/pages/Processes.tsx
+++ b/src/pages/Processes.tsx
@@ -42,7 +42,6 @@ interface IProps extends WrappedComponentProps {}
 interface IState {
     showExplanation: boolean;
     showConfirmDialog: ShowConfirmDialogType;
-    cancelConfirmDialog: () => void;
 }
 
 class Processes extends React.PureComponent<IProps, IState> {
@@ -52,7 +51,6 @@ class Processes extends React.PureComponent<IProps, IState> {
         this.state = {
             showExplanation: false,
             showConfirmDialog: () => {},
-            cancelConfirmDialog: () => {},
         };
     }
 

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -68,7 +68,9 @@ export default class SubscriptionsPage extends React.PureComponent<IProps, IStat
     }
 
     addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog });
+        }
         return <></>;
     };
 

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -153,7 +153,9 @@ class Tasks extends React.PureComponent<IProps, IState> {
     }
 
     addConfirmDialogActions = ({ showConfirmDialog }: ConfirmDialogActions) => {
-        this.setState({ showConfirmDialog });
+        if (this.state.showConfirmDialog !== showConfirmDialog) {
+            this.setState({ showConfirmDialog });
+        }
         return <></>;
     };
 


### PR DESCRIPTION
components had their own confirmation dialog which is now changed to a contextprovider which all components can use.