### PR TITLE
Fix sync toast position that made the page jump up and down

### DIFF
--- a/src/components/Navigation.scss
+++ b/src/components/Navigation.scss
@@ -18,10 +18,10 @@
 @use "../stylesheets/vars";
 
 .sync {
-    position: fixed;
+    position: fixed !important;
     bottom: 8px;
     left: 8px;
-    width: auto;
+    width: auto !important;
     z-index: map-get(vars.$z-index, sync);
     &__label {
         font-size: 0.875em;


### PR DESCRIPTION
fixed it with adding `!important` to the `sync` class, don't know if we should fix it directly in `.euitoast` class from elastic ui.

fixes the sync from looking like this:
![image](https://user-images.githubusercontent.com/16774022/169989606-d257e880-eaca-495f-a340-651d19b83bbc.png)
to:
![image](https://user-images.githubusercontent.com/16774022/169989749-aedf74cd-17cb-4eb4-a496-9174bd508dc6.png)
