### PR TITLE
Allow user to specify 'label' for dynamic form field label creation

### DIFF
--- a/src/components/inputForms/UserInputForm.tsx
+++ b/src/components/inputForms/UserInputForm.tsx
@@ -189,7 +189,7 @@ class CustomTitleJSONSchemaBridge extends JSONSchemaBridge {
     getProps(name: string) {
         let props = super.getProps(name);
         const translation_key = name.replace(/\.\d+(.\d+)*/, "_fields");
-        let label = intl.formatMessage({ id: `forms.fields.${translation_key}` });
+        let label = props.label === undefined ? intl.formatMessage({ id: `forms.fields.${translation_key}` }) : props.label
 
         // Mark required inputs. Might be delegated to the form components itself in the future.
         if (props.required && !props.readOnly && !props.isDisabled && !name.includes(".")) {
@@ -290,11 +290,11 @@ class UserInputForm extends React.Component<IProps, IState> {
         processing: false,
         nrOfValidationErrors: 0,
         rootErrors: [],
-        showConfirmDialog: () => {},
+        showConfirmDialog: () => { },
     };
 
     public static defaultProps = {
-        previous: () => {},
+        previous: () => { },
         hasPrev: false,
         hasNext: false,
     };
@@ -303,7 +303,7 @@ class UserInputForm extends React.Component<IProps, IState> {
         stop(e);
         this.state.showConfirmDialog({
             question: "",
-            confirmAction: () => {},
+            confirmAction: () => { },
             cancelAction: this.props.cancel,
             leavePage: true,
         });
@@ -414,7 +414,7 @@ class UserInputForm extends React.Component<IProps, IState> {
         const { nrOfValidationErrors, rootErrors } = this.state;
         const { stepUserInput, userInput, location } = this.props;
         const prefilledForm = fillPreselection(stepUserInput, location.search);
-        const bridge = new CustomTitleJSONSchemaBridge(prefilledForm, () => {});
+        const bridge = new CustomTitleJSONSchemaBridge(prefilledForm, () => { });
 
         const AutoFieldProvider = AutoField.componentDetectorContext.Provider;
 

--- a/src/lib/uniforms-surfnet/src/RadioField.tsx
+++ b/src/lib/uniforms-surfnet/src/RadioField.tsx
@@ -40,7 +40,7 @@ function Radio({
 }: RadioFieldProps) {
     return (
         <div {...omit(filterDOMProps(props), ["checkboxes"])}>
-            {label && <label>{label}</label>}
+            {label && <label style={{ fontWeight: "bolder" }}>{label}</label>}
 
             {allowedValues?.map((item) => (
                 <div key={item}>
@@ -57,7 +57,7 @@ function Radio({
                         type="radio"
                     />
 
-                    <label htmlFor={`${id}-${escape(item)}`}>{transform ? transform(item) : item}</label>
+                    <label htmlFor={`${id}-${escape(item)}`} style={{ paddingLeft: "5px" }}>{transform ? transform(item) : item}</label>
                 </div>
             ))}
         </div>


### PR DESCRIPTION
One of our ESnet Orchestrated services is "Physical Connection Service", which allows network engineers to create & manage subscriptions that configure physical interfaces on network devices.

A recent feature request was to make the configuration more granular for LAG interfaces: allowing configuration for the admin-state (shutdown true/false) for individual LAG member ports, as well as the LAG interface itself.

I couldn't find a way to use the `en.ts` or `i18n` translations to map a custom, dynamic label to a form field.

For example:
Say there is a LAG interface "lag-2", which aggregates interfaces "1/1/c5/1" and "1/1/c6/1" on device "ALU-1".

One could make the _value_ associated to a radio button or drop-down select field look like this in the rendered form:
```
● connection: alu-1:lag-2 admin state -- UP
○ connection: alu-1:lag-2 admin state -- DOWN
○ connection: alu-1:lag-2 admin state -- NO-CONFIG

○ connection: alu-1:1/1/c5/1 admin state -- UP
● connection: alu-1:1/1/c5/1 admin state -- DOWN
...
```
Using a `Choice` `strEnum` type, 
But the interface might be more informative and cleaner when it's rendered as
```
connection: alu-1:lag-2 admin state
● up
○ down
○ no-config
```
or 
```
connection: alu-1:lag-2 admin state
┌─────────────────────────────────┐
│  up                       X | ▼ │ 
└─────────────────────────────────┘
```
Currently, for most form field labels, one must define a translation in `src/locale/en.ts`. For example:
```
...
  forms: {
    ...
    fields: {
      port_state_0: "Select admin state for interface 0",
...
```
There does not appear to be a "dynamic" translation available for `forms.fields.${field label}`, as is possible elsewhere in the translations by using templating double curly braces for the translated value (or I am doing something wrong when attempting to use that method—entirely too possible).

With the small changes in this PR, a backend form can be created dynamically in Python within a for loop, using `pydantic.create_model("SelectLagForm", __base__=FormPage, {...field definitions})` or `type("SelectLagForm", (FormPage,), {...field definitions})` that if defined normally would look like:
```python
class SelectLagForm(FormPage):
    port_state_0: IfaceStateEnum = Field(label="connection: alu-1:lag-2", default=IfaceStateEnum.UP)
    port_state_1: LagMemberStateEnum = Field(label="connection: alu-1:1/1/c5/1", default=LagMemberStateEnum.DOWN)
    port_state_2: LagMemberStateEnum = Field(label="connection: alu-1:1/1/c6/1", default=LagMemberStateEnum.UP
```
And it will render on the frontend GUI as shown in the example above.

Whoever reviews this, please let me know if there is a different approach that already exists to achieve this functionality. I would gladly do that over modifying/duplicating in upstream code!
