### PR TITLE
Scroll to last step in process details when page is loaded except when process is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `#157` Redirect workflow submit to process detail
 - `#158` Add auto scrolling to last finished step in process details, a button to turn auto scrolling off or on and add fixed top menu when scrolling past actions on the page.
+- `#161` Scroll to last step in process details when page is loaded except when process is done and fix summaryfield error.
 
 Surf specific:
 - `#155` cim: Check if impacted service has subscription id before calling api

--- a/src/lib/uniforms-surfnet/src/SummaryField.tsx
+++ b/src/lib/uniforms-surfnet/src/SummaryField.tsx
@@ -42,7 +42,9 @@ function Summary({ id, name, label, description, onChange, data, ...props }: Sum
     const rows = columns[0].map((row, index) => (
         <tr key={index}>
             {labels && <td className={`label ${theme}`}>{labels[index]}</td>}
-            <td className={`value ${theme}`}>{row.includes("<!doctype html>") ? ReactHtmlParser(row) : row}</td>
+            <td className={`value ${theme}`}>
+                {typeof row == "string" && row.includes("<!doctype html>") ? ReactHtmlParser(row) : row}
+            </td>
             {extra_columns_data &&
                 extra_columns_data.map((cell, idx) => (
                     <td className={`value ${theme}`} key={idx}>

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -117,6 +117,9 @@ class ProcessDetail extends React.PureComponent<IProps, IState> {
             .processSubscriptionsByProcessId(enrichedProcess.id)
             .then((res) => {
                 this.setState({ subscriptionProcesses: res, loaded: true });
+                if (enrichedProcess.step !== "Done") {
+                    this.scrollToLast();
+                }
             })
             .catch((err) => {
                 if (err.response && err.response.status === 404) {


### PR DESCRIPTION
- fix summaryfield by checking if row is string.