### PR TITLE
Fix explain in the form sending you back to the start

### DIFF
--- a/src/custom-surf/components/FormHeader.tsx
+++ b/src/custom-surf/components/FormHeader.tsx
@@ -1,0 +1,29 @@
+import { EuiPageHeader } from "@elastic/eui";
+import Explain from "components/Explain";
+import { ReactNode, useState } from "react";
+
+interface IProps {
+    title: ReactNode;
+    explainTitle: string;
+    explainDescription: ReactNode;
+}
+
+export default function FormHeader({ title, explainTitle, explainDescription }: IProps) {
+    const [showExplanation, setShowExplanation] = useState(false);
+
+    return (
+        <>
+            <EuiPageHeader
+                pageTitle={title}
+                rightSideItems={[
+                    <section className="explain">
+                        <i className="fa fa-question-circle" onClick={() => setShowExplanation(true)} />
+                    </section>,
+                ]}
+            />
+            <Explain close={() => setShowExplanation(false)} isVisible={showExplanation} title={explainTitle}>
+                {explainDescription}
+            </Explain>
+        </>
+    );
+}

--- a/src/custom-surf/pages/CloseServiceTicket.tsx
+++ b/src/custom-surf/pages/CloseServiceTicket.tsx
@@ -18,7 +18,7 @@ import OpenForm from "custom/components/cim/OpenForm";
 import FormHeader from "custom/components/FormHeader";
 import { formStyling } from "custom/pages/FormStyling";
 import { CloseServiceTicketPayload } from "custom/types";
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { useParams } from "react-router";
 import ApplicationContext from "utils/ApplicationContext";
 

--- a/src/custom-surf/pages/CloseServiceTicket.tsx
+++ b/src/custom-surf/pages/CloseServiceTicket.tsx
@@ -13,12 +13,12 @@
  *
  */
 
-import { EuiPage, EuiPageBody, EuiPageHeader } from "@elastic/eui";
-import Explain from "components/Explain";
+import { EuiPage, EuiPageBody } from "@elastic/eui";
 import OpenForm from "custom/components/cim/OpenForm";
+import FormHeader from "custom/components/FormHeader";
 import { formStyling } from "custom/pages/FormStyling";
 import { CloseServiceTicketPayload } from "custom/types";
-import React, { useContext, useState } from "react";
+import { useContext, useState } from "react";
 import { useParams } from "react-router";
 import ApplicationContext from "utils/ApplicationContext";
 
@@ -28,7 +28,6 @@ interface IProps {
 
 export default function CloseServiceTicket() {
     const { id } = useParams<IProps>();
-    const [showExplanation, setShowExplanation] = useState(false);
     const { redirect, customApiClient } = useContext(ApplicationContext);
 
     const handleSubmit = (userInputs: any) => {
@@ -51,20 +50,16 @@ export default function CloseServiceTicket() {
     return (
         <EuiPage css={formStyling}>
             <EuiPageBody component="div">
-                <EuiPageHeader
-                    pageTitle="Prepare to send CLOSE email to institutes"
-                    rightSideItems={[
-                        <section className="explain">
-                            <i className="fa fa-question-circle" onClick={() => setShowExplanation(true)} />
-                        </section>,
-                    ]}
+                <FormHeader
+                    title="Prepare to send CLOSE email to institutes"
+                    explainTitle="What is this?"
+                    explainDescription={
+                        <p>
+                            This wizard will guide you through the process of closing the ticket and sending the CLOSE
+                            email to institutes.
+                        </p>
+                    }
                 />
-                <Explain close={() => setShowExplanation(false)} isVisible={showExplanation} title="What is this?">
-                    <p>
-                        This wizard will guide you through the process of closing the ticket and sending the CLOSE email
-                        to institutes.
-                    </p>
-                </Explain>
                 <OpenForm
                     formKey="close_ticket_form"
                     handleSubmit={handleSubmit}

--- a/src/custom-surf/pages/CreateServiceTicket.tsx
+++ b/src/custom-surf/pages/CreateServiceTicket.tsx
@@ -18,7 +18,7 @@ import CreateForm from "custom/components/cim/CreateForm";
 import FormHeader from "custom/components/FormHeader";
 import { formStyling } from "custom/pages/FormStyling";
 import { CreateServiceTicketPayload } from "custom/types";
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import ApplicationContext from "utils/ApplicationContext";
 
 export default function CreateServiceTicket() {

--- a/src/custom-surf/pages/CreateServiceTicket.tsx
+++ b/src/custom-surf/pages/CreateServiceTicket.tsx
@@ -13,16 +13,15 @@
  *
  */
 
-import { EuiPage, EuiPageBody, EuiPageHeader } from "@elastic/eui";
-import Explain from "components/Explain";
+import { EuiPage, EuiPageBody } from "@elastic/eui";
 import CreateForm from "custom/components/cim/CreateForm";
+import FormHeader from "custom/components/FormHeader";
 import { formStyling } from "custom/pages/FormStyling";
 import { CreateServiceTicketPayload } from "custom/types";
 import React, { useContext, useState } from "react";
 import ApplicationContext from "utils/ApplicationContext";
 
 export default function CreateServiceTicket() {
-    const [showExplanation, setShowExplanation] = useState(false);
     const { redirect, customApiClient } = useContext(ApplicationContext);
 
     const handleSubmit = (userInputs: any) => {
@@ -38,21 +37,13 @@ export default function CreateServiceTicket() {
     return (
         <EuiPage css={formStyling}>
             <EuiPageBody component="div">
-                <EuiPageHeader
-                    pageTitle="Create ticket"
-                    rightSideItems={[
-                        <section className="explain">
-                            <i className="fa fa-question-circle" onClick={() => setShowExplanation(true)} />
-                        </section>,
-                    ]}
+                <FormHeader
+                    title="Create ticket"
+                    explainTitle="How to create a CIM ticket"
+                    explainDescription={
+                        <p>Starting a ticket will execute a state machine that guides you through the process.</p>
+                    }
                 />
-                <Explain
-                    close={() => setShowExplanation(false)}
-                    isVisible={showExplanation}
-                    title="How to create a CIM ticket"
-                >
-                    <p>Starting a ticket will execute a state machine that guides you through the process.</p>
-                </Explain>
                 <CreateForm formKey="create_ticket_form" handleSubmit={handleSubmit} />
             </EuiPageBody>
         </EuiPage>

--- a/src/custom-surf/pages/OpenServiceTicket.tsx
+++ b/src/custom-surf/pages/OpenServiceTicket.tsx
@@ -13,37 +13,17 @@
  *
  */
 
-import { EuiPage, EuiPageBody, EuiPageHeader } from "@elastic/eui";
-import Explain from "components/Explain";
+import { EuiPage, EuiPageBody } from "@elastic/eui";
 import OpenForm from "custom/components/cim/OpenForm";
+import FormHeader from "custom/components/FormHeader";
 import { formStyling } from "custom/pages/FormStyling";
 import { OpenServiceTicketPayload } from "custom/types";
-import React, { useContext, useState } from "react";
+import { useContext } from "react";
 import { useParams } from "react-router";
 import ApplicationContext from "utils/ApplicationContext";
 
 interface IProps {
     id: string;
-}
-
-function FormHeader() {
-    const [showExplanation, setShowExplanation] = useState(false);
-
-    return (
-        <>
-            <EuiPageHeader
-                pageTitle="Prepare to send OPEN email to institutes"
-                rightSideItems={[
-                    <section className="explain">
-                        <i className="fa fa-question-circle" onClick={() => setShowExplanation(true)} />
-                    </section>,
-                ]}
-            />
-            <Explain close={() => setShowExplanation(false)} isVisible={showExplanation} title="What is this?">
-                <p>This wizard will guide you through the process of sending the OPEN email to institutes.</p>
-            </Explain>
-        </>
-    );
 }
 
 export default function OpenServiceTicket() {
@@ -69,7 +49,13 @@ export default function OpenServiceTicket() {
     return (
         <EuiPage css={formStyling}>
             <EuiPageBody component="div">
-                <FormHeader />
+                <FormHeader
+                    title="Prepare to send OPEN email to institutes"
+                    explainTitle="What is this?"
+                    explainDescription={
+                        <p>This wizard will guide you through the process of sending the OPEN email to institutes.</p>
+                    }
+                />
                 <OpenForm
                     formKey="open_ticket_form"
                     handleSubmit={handleSubmit}

--- a/src/custom-surf/pages/OpenServiceTicket.tsx
+++ b/src/custom-surf/pages/OpenServiceTicket.tsx
@@ -26,9 +26,28 @@ interface IProps {
     id: string;
 }
 
+function FormHeader() {
+    const [showExplanation, setShowExplanation] = useState(false);
+
+    return (
+        <>
+            <EuiPageHeader
+                pageTitle="Prepare to send OPEN email to institutes"
+                rightSideItems={[
+                    <section className="explain">
+                        <i className="fa fa-question-circle" onClick={() => setShowExplanation(true)} />
+                    </section>,
+                ]}
+            />
+            <Explain close={() => setShowExplanation(false)} isVisible={showExplanation} title="What is this?">
+                <p>This wizard will guide you through the process of sending the OPEN email to institutes.</p>
+            </Explain>
+        </>
+    );
+}
+
 export default function OpenServiceTicket() {
     const { id } = useParams<IProps>();
-    const [showExplanation, setShowExplanation] = useState(false);
     const { redirect, customApiClient } = useContext(ApplicationContext);
 
     const handleSubmit = (userInputs: any) => {
@@ -50,17 +69,7 @@ export default function OpenServiceTicket() {
     return (
         <EuiPage css={formStyling}>
             <EuiPageBody component="div">
-                <EuiPageHeader
-                    pageTitle="Prepare to send OPEN email to institutes"
-                    rightSideItems={[
-                        <section className="explain">
-                            <i className="fa fa-question-circle" onClick={() => setShowExplanation(true)} />
-                        </section>,
-                    ]}
-                />
-                <Explain close={() => setShowExplanation(false)} isVisible={showExplanation} title="What is this?">
-                    <p>This wizard will guide you through the process of sending the OPEN email to institutes.</p>
-                </Explain>
+                <FormHeader />
                 <OpenForm
                     formKey="open_ticket_form"
                     handleSubmit={handleSubmit}

--- a/src/custom-surf/pages/UpdateServiceTicket.tsx
+++ b/src/custom-surf/pages/UpdateServiceTicket.tsx
@@ -13,12 +13,12 @@
  *
  */
 
-import { EuiPage, EuiPageBody, EuiPageHeader } from "@elastic/eui";
-import Explain from "components/Explain";
+import { EuiPage, EuiPageBody } from "@elastic/eui";
 import OpenForm from "custom/components/cim/OpenForm";
+import FormHeader from "custom/components/FormHeader";
 import { formStyling } from "custom/pages/FormStyling";
 import { UpdateServiceTicketPayload } from "custom/types";
-import React, { useContext, useState } from "react";
+import { useContext } from "react";
 import { useParams } from "react-router";
 import ApplicationContext from "utils/ApplicationContext";
 
@@ -28,7 +28,6 @@ interface IProps {
 
 export default function UpdateServiceTicket() {
     const { id } = useParams<IProps>();
-    const [showExplanation, setShowExplanation] = useState(false);
     const { redirect, customApiClient } = useContext(ApplicationContext);
 
     const handleSubmit = (userInputs: any) => {
@@ -53,17 +52,13 @@ export default function UpdateServiceTicket() {
     return (
         <EuiPage css={formStyling}>
             <EuiPageBody component="div">
-                <EuiPageHeader
-                    pageTitle="Prepare to send UPDATE email to institutes"
-                    rightSideItems={[
-                        <section className="explain">
-                            <i className="fa fa-question-circle" onClick={() => setShowExplanation(true)} />
-                        </section>,
-                    ]}
+                <FormHeader
+                    title="Prepare to send UPDATE email to institutes"
+                    explainTitle="What is this?"
+                    explainDescription={
+                        <p>This wizard will guide you through the process of sending the UPDATE email to institutes.</p>
+                    }
                 />
-                <Explain close={() => setShowExplanation(false)} isVisible={showExplanation} title="What is this?">
-                    <p>This wizard will guide you through the process of sending the UPDATE email to institutes.</p>
-                </Explain>
                 <OpenForm
                     formKey="update_ticket_form"
                     handleSubmit={handleSubmit}


### PR DESCRIPTION
The Explain rerenders `OpenServiceTicket` component and also rerenders the form, moving you to the start of the form.