### PR TITLE
add variable for local dev cim host

### DIFF
--- a/src/custom-surf/api/index.ts
+++ b/src/custom-surf/api/index.ts
@@ -26,7 +26,7 @@ import { CreateServiceTicketPayload } from "../types";
 
 function prefix_cim_dev_uri(uri: string): string {
     return process.env.NODE_ENV === "development"
-        ? `http://localhost:${process.env.REACT_APP_CIM_PORT ?? 8081}/${uri.replace("surf/", "")}`
+        ? `${process.env.REACT_APP_CIM_HOST ?? "http://localhost"}:${process.env.REACT_APP_CIM_PORT ?? 8081}/${uri.replace("surf/", "")}`
         : uri;
 }
 


### PR DESCRIPTION
Make the CIM host for local development a variable so that we can also run a dev server on k8s. On k8s stuff will not work when we hardcode the hostname to localhost.