### PR TITLE
cim#18 Use transition instead of process_state as much as possible

### DIFF
--- a/src/custom-surf/api/index.ts
+++ b/src/custom-surf/api/index.ts
@@ -3,7 +3,7 @@ import {
     OpenServiceTicketPayload,
     ServiceTicket,
     ServiceTicketBackgroundJobCount,
-    ServiceTicketProcessState,
+    ServiceTicketTransition,
     ServiceTicketWithDetails,
 } from "custom/types";
 import { intl } from "locale/i18n";
@@ -230,6 +230,14 @@ export class CustomApiClient extends CustomApiClientInterface {
         return this.postPutJson(prefix_cim_dev_uri("surf/cim/tickets"), ticket, "post", false, true);
     };
 
+    cimAcceptTicket = (ticket_id: string): Promise<ServiceTicketWithDetails> => {
+        return this.postPutJson(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/accept`), {}, "post", false);
+    };
+
+    cimAbortTicket = (ticket_id: string): Promise<ServiceTicketWithDetails> => {
+        return this.postPutJson(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/abort`), {}, "post", false);
+    };
+
     cimOpenTicket = (payload: OpenServiceTicketPayload): Promise<{ id: string }> => {
         return this.postPutJson(
             prefix_cim_dev_uri(`surf/cim/tickets/${payload.cim_ticket_id}/open`),
@@ -277,13 +285,9 @@ export class CustomApiClient extends CustomApiClientInterface {
         return this.fetchJson<ServiceTicketWithDetails>(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}`));
     };
 
-    // todo cim#18
-    cimChangeTicketStateById = (
-        ticket_id: string,
-        state: ServiceTicketProcessState
-    ): Promise<ServiceTicketWithDetails> => {
-        return this.fetchJson<ServiceTicketWithDetails>(
-            prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/state/${state}`)
+    cimGetAllowedTransitions = (ticket_id: string): Promise<ServiceTicketTransition[]> => {
+        return this.fetchJson<ServiceTicketTransition[]>(
+            prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/transitions`)
         );
     };
 

--- a/src/custom-surf/components/cim/OpenForm.tsx
+++ b/src/custom-surf/components/cim/OpenForm.tsx
@@ -14,7 +14,6 @@
  */
 
 import UserInputFormWizard from "components/inputForms/UserInputFormWizard";
-import { ServiceTicketProcessState } from "custom/types";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import ApplicationContext from "utils/ApplicationContext";
@@ -36,8 +35,7 @@ export default function OpenForm({ formKey, ticketId, handleSubmit, handleCancel
 
     const submit = useCallback(
         (userInputs: {}[]) => {
-            // Pass the ticket id and next process state. Backend validates the state transition.
-            userInputs = [{ ticket_id: ticketId, next_process_state: ServiceTicketProcessState.OPEN }, ...userInputs];
+            userInputs = [{ ticket_id: ticketId }, ...userInputs];
             let promise = customApiClient.cimStartForm(formKey, userInputs).then(
                 (form) => {
                     handleSubmit(form);

--- a/src/custom-surf/pages/ServiceTicketDetail.tsx
+++ b/src/custom-surf/pages/ServiceTicketDetail.tsx
@@ -257,12 +257,7 @@ const ServiceTicketDetail = () => {
         actions.splice(2, 0, {
             translation: "tickets.action.open_and_close",
             onClick: openAndCloseTicket,
-            // TODO cim#18: refactor open_and_close to be its own transition
-            requiredStates: [
-                ServiceTicketProcessState.OPEN_ACCEPTED,
-                ServiceTicketProcessState.OPEN,
-                ServiceTicketProcessState.UPDATED,
-            ],
+            transition: ServiceTicketTransition.OPEN_AND_CLOSE,
         });
     }
 

--- a/src/custom-surf/pages/ServiceTickets.tsx
+++ b/src/custom-surf/pages/ServiceTickets.tsx
@@ -16,7 +16,7 @@ import {
 } from "@elastic/eui";
 import ServiceTicketFilter from "custom/components/ServiceTicketFilter";
 import { tableTickets } from "custom/pages/ServiceTicketsStyling";
-import { ServiceTicket, ServiceTicketProcessState } from "custom/types";
+import { ServiceTicket, ServiceTicketProcessState, ServiceTicketTransition } from "custom/types";
 import { renderStringAsDateTime } from "custom/Utils";
 import { intl } from "locale/i18n";
 import debounce from "lodash/debounce";
@@ -311,19 +311,20 @@ class ServiceTickets extends React.PureComponent<IProps, IState> {
                                         data-label={intl.formatMessage({ id: "tickets.table.jira_ticket_id" })}
                                         className="jira_ticket_id"
                                     >
-                                        {ticket.process_state === "initial" && !ticket.transition_action && (
-                                            <EuiIconTip
-                                                aria-label="Warning"
-                                                size="l"
-                                                type="alert"
-                                                color="warning"
-                                                content={intl.formatMessage({
-                                                    id: "tickets.table.background_job_warning",
-                                                })}
-                                            />
-                                        )}
-                                        {ticket.process_state === "initial" &&
-                                            ticket.transition_action === "relating" && (
+                                        {ticket.process_state === ServiceTicketProcessState.NEW &&
+                                            !ticket.transition_action && (
+                                                <EuiIconTip
+                                                    aria-label="Warning"
+                                                    size="l"
+                                                    type="alert"
+                                                    color="warning"
+                                                    content={intl.formatMessage({
+                                                        id: "tickets.table.background_job_warning",
+                                                    })}
+                                                />
+                                            )}
+                                        {ticket.process_state === ServiceTicketProcessState.NEW &&
+                                            ticket.transition_action === ServiceTicketTransition.RELATING && (
                                                 <EuiLoadingSpinner size="s" style={{ marginRight: "9px" }} />
                                             )}
                                         <Link to={`/tickets/${ticket._id}`}>{ticket.jira_ticket_id}</Link>

--- a/src/custom-surf/types.ts
+++ b/src/custom-surf/types.ts
@@ -33,13 +33,6 @@ export interface CloseServiceTicketPayload extends OpenServiceTicketPayload {
     end_date?: string;
 }
 
-export enum ServiceTicketState {
-    INITIAL = "initial",
-    ACTIVE = "active",
-    ABORTED = "aborted",
-    CLOSED = "closed",
-}
-
 export enum ServiceTicketProcessState {
     NEW = "new",
     OPEN = "open",

--- a/src/custom-surf/types.ts
+++ b/src/custom-surf/types.ts
@@ -41,13 +41,23 @@ export enum ServiceTicketState {
 }
 
 export enum ServiceTicketProcessState {
-    INITIAL = "initial",
+    NEW = "new",
     OPEN = "open",
     OPEN_RELATED = "open_related",
     OPEN_ACCEPTED = "open_accepted",
     UPDATED = "updated",
     ABORTED = "aborted",
     CLOSED = "closed",
+}
+
+export enum ServiceTicketTransition {
+    RELATING = "relating",
+    ACCEPTING = "accepting",
+    ABORTING = "aborting",
+    OPENING = "opening",
+    UPDATING = "updating",
+    CLOSING = "closing",
+    CLEANING = "cleaning",
 }
 
 export interface ServiceTicket {

--- a/src/custom-surf/types.ts
+++ b/src/custom-surf/types.ts
@@ -48,6 +48,7 @@ export enum ServiceTicketTransition {
     ACCEPTING = "accepting",
     ABORTING = "aborting",
     OPENING = "opening",
+    OPEN_AND_CLOSE = "open_and_close",
     UPDATING = "updating",
     CLOSING = "closing",
     CLEANING = "cleaning",


### PR DESCRIPTION
* Use available ticket transitions to decide which buttons to show, and change ticket state by applying transitions
* Renamed `ServiceTicketProcessState.INITIAL` to `ServiceTicketProcessState.NEW`
* Added `ServiceTicketTransition` enum
* Removed `ServiceTicketState` enum