### PR TITLE
Cim#44 Allow recovering ticket inform job

### DIFF
--- a/src/custom-surf/api/index.ts
+++ b/src/custom-surf/api/index.ts
@@ -327,6 +327,15 @@ export class CustomApiClient extends CustomApiClientInterface {
             true
         );
     };
+    cimRestartInform = (ticket_id: string): Promise<{ id: string }> => {
+        return this.postPutJson(
+            prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/restart-inform`),
+            {},
+            "post",
+            false,
+            true
+        );
+    };
     cimBackgroundJobCount = (): Promise<ServiceTicketBackgroundJobCount> => {
         return this.fetchJson<ServiceTicketBackgroundJobCount>(
             prefix_cim_dev_uri("surf/cim/tickets/active-background-jobs")

--- a/src/custom-surf/api/index.ts
+++ b/src/custom-surf/api/index.ts
@@ -287,8 +287,19 @@ export class CustomApiClient extends CustomApiClientInterface {
         return this.fetchJson<ServiceTicket[]>(prefix_cim_dev_uri("surf/cim/tickets"));
     };
 
+    _cimTicketById = (ticket_id: string, show_error_dialog: boolean): Promise<ServiceTicketWithDetails> => {
+        return this.fetchJson<ServiceTicketWithDetails>(
+            prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}`),
+            {},
+            {},
+            show_error_dialog
+        );
+    };
     cimTicketById = (ticket_id: string): Promise<ServiceTicketWithDetails> => {
-        return this.fetchJson<ServiceTicketWithDetails>(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}`));
+        return this._cimTicketById(ticket_id, true);
+    };
+    cimTicketByIdNoErrorDialog = (ticket_id: string): Promise<ServiceTicketWithDetails> => {
+        return this._cimTicketById(ticket_id, false);
     };
 
     cimGetAllowedTransitions = (ticket_id: string): Promise<ServiceTicketTransition[]> => {

--- a/src/custom-surf/api/index.ts
+++ b/src/custom-surf/api/index.ts
@@ -232,14 +232,17 @@ export class CustomApiClient extends CustomApiClientInterface {
         return this.postPutJson(prefix_cim_dev_uri("surf/cim/tickets"), ticket, "post", false, true);
     };
 
+    /* TODO cim#50 reduce api boilerplate */
     cimAcceptTicket = (ticket_id: string): Promise<ServiceTicketWithDetails> => {
         return this.postPutJson(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/accept`), {}, "post", false);
     };
 
+    /* TODO cim#50 reduce api boilerplate */
     cimAbortTicket = (ticket_id: string): Promise<ServiceTicketWithDetails> => {
         return this.postPutJson(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/abort`), {}, "post", false);
     };
 
+    /* TODO cim#50 reduce api boilerplate */
     cimOpenTicket = (payload: OpenServiceTicketPayload): Promise<{ id: string }> => {
         return this.postPutJson(
             prefix_cim_dev_uri(`surf/cim/tickets/${payload.cim_ticket_id}/open`),
@@ -249,6 +252,7 @@ export class CustomApiClient extends CustomApiClientInterface {
             true
         );
     };
+    /* TODO cim#50 reduce api boilerplate */
     cimOpenAndCloseTicket = (payload: OpenServiceTicketPayload): Promise<{ id: string }> => {
         return this.postPutJson(
             prefix_cim_dev_uri(`surf/cim/tickets/${payload.cim_ticket_id}/open-and-close`),
@@ -259,6 +263,7 @@ export class CustomApiClient extends CustomApiClientInterface {
         );
     };
 
+    /* TODO cim#50 reduce api boilerplate */
     cimUpdateTicket = (payload: OpenServiceTicketPayload): Promise<{ id: string }> => {
         return this.postPutJson(
             prefix_cim_dev_uri(`surf/cim/tickets/${payload.cim_ticket_id}/update`),
@@ -273,6 +278,7 @@ export class CustomApiClient extends CustomApiClientInterface {
         return this.fetchJson<ServiceTicket>(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/metadata`));
     };
 
+    /* TODO cim#50 reduce api boilerplate */
     cimCloseTicket = (payload: OpenServiceTicketPayload): Promise<{ id: string }> => {
         return this.postPutJson(
             prefix_cim_dev_uri(`surf/cim/tickets/${payload.cim_ticket_id}/close`),

--- a/src/custom-surf/components/cim/ImpactedObjects.tsx
+++ b/src/custom-surf/components/cim/ImpactedObjects.tsx
@@ -273,7 +273,7 @@ const ImpactedObjects = ({ ticket, updateable, withSubscriptions }: IProps) => {
                     </EuiModalHeader>
                     <EuiModalBody>{editImpactedObject && showImpact(editImpactedObject)}</EuiModalBody>
                     <EuiModalFooter>
-                        <EuiButton onClick={closeModal} fill>
+                        <EuiButton onClick={closeModal} aria-label="Close modal" fill>
                             Close
                         </EuiButton>
                     </EuiModalFooter>
@@ -292,6 +292,7 @@ const ImpactedObjects = ({ ticket, updateable, withSubscriptions }: IProps) => {
                         size="m"
                         onClick={toggleExpandAll}
                         iconType={!isEmpty(itemIdToExpandedRowMap) ? "arrowUp" : "arrowDown"}
+                        aria-label={!isEmpty(itemIdToExpandedRowMap) ? "Collapse" : "Expand"}
                     ></EuiButtonIcon>
                 </EuiFlexItem>
             </EuiFlexGrid>

--- a/src/custom-surf/components/cim/OpenForm.tsx
+++ b/src/custom-surf/components/cim/OpenForm.tsx
@@ -42,8 +42,13 @@ export default function OpenForm({ formKey, ticketId, handleSubmit, handleCancel
                     setFlash(intl.formatMessage({ id: `cim.flash.${formKey}` }));
                 },
                 (e) => {
-                    if (e.response.status === 400 && e.response.data?.title === "Invalid statemachine transition") {
-                        setFlash(e.response.data.title, "error");
+                    if (
+                        e.response.status === 400 &&
+                        ["invalid statemachine transition", "unfinished inform"].includes(
+                            e.response.data?.title.toLowerCase()
+                        )
+                    ) {
+                        setFlash(e.response.data.detail, "error");
                         redirect(`/tickets/${ticketId}`);
                     }
                     throw e;

--- a/src/custom-surf/pages/ServiceTicketDetail.tsx
+++ b/src/custom-surf/pages/ServiceTicketDetail.tsx
@@ -109,9 +109,13 @@ const ServiceTicketDetail = () => {
     const showModal = () => setIsModalVisible(true);
 
     useInterval(async () => {
+        try {
+            const ticket = await customApiClient.cimTicketByIdNoErrorDialog(id);
         console.log("Refreshing");
-        const ticket = await customApiClient.cimTicketById(id);
         setTicket(ticket);
+        } catch (err) {
+            /* Suppress any errors during refresh */
+        }
     }, 5000);
 
     useEffect(() => {

--- a/src/custom-surf/pages/ServiceTicketDetail.tsx
+++ b/src/custom-surf/pages/ServiceTicketDetail.tsx
@@ -212,6 +212,33 @@ const ServiceTicketDetail = () => {
     const viewLastSentMails = () => {
         redirect(`/tickets/${ticket_id}/mails`);
     };
+    const restartOpenRelate = () => {
+        customApiClient.cimRestartOpenRelate(ticket_id).then(() => {
+            setFlash(
+                intl.formatMessage({
+                    id: "tickets.action.background_job_restarted",
+                })
+            );
+            redirect(`/tickets/${ticket_id}`);
+        });
+    };
+    const restartInformJob = () => {
+        customApiClient
+            .cimRestartInform(ticket_id)
+            .then(() => {
+                setFlash(
+                    intl.formatMessage({
+                        id: "tickets.action.inform_job_restarted",
+                    })
+                );
+                redirect(`/tickets/${ticket_id}`);
+            })
+            .catch((err) => {
+                if (err.response && err.response.status === 400) {
+                    setFlash(err.response.data.detail, "error");
+                }
+            });
+    };
 
     const onButtonClick = (question: string, confirm: (e: React.MouseEvent<HTMLButtonElement>) => void) => {
         showConfirmDialog({
@@ -330,16 +357,7 @@ const ServiceTicketDetail = () => {
                                             isDisabled={false}
                                             size="m"
                                             fill
-                                            onClick={() =>
-                                                customApiClient.cimRestartOpenRelate(ticket._id).then(() => {
-                                                    setFlash(
-                                                        intl.formatMessage({
-                                                            id: "tickets.action.background_job_restarted",
-                                                        })
-                                                    );
-                                                    redirect(`/tickets/${ticket._id}`);
-                                                })
-                                            }
+                                            onClick={restartOpenRelate}
                                         >
                                             {intl.formatMessage({ id: "tickets.action.restart_open_relate" })}
                                         </EuiButton>
@@ -354,23 +372,7 @@ const ServiceTicketDetail = () => {
                                         isDisabled={false}
                                         size="m"
                                         fill
-                                        onClick={() =>
-                                            customApiClient
-                                                .cimRestartInform(ticket._id)
-                                                .then(() => {
-                                                    setFlash(
-                                                        intl.formatMessage({
-                                                            id: "tickets.action.inform_job_restarted",
-                                                        })
-                                                    );
-                                                    redirect(`/tickets/${ticket._id}`);
-                                                })
-                                                .catch((err) => {
-                                                    if (err.response && err.response.status === 400) {
-                                                        setFlash(err.response.data.detail, "error");
-                                                    }
-                                                })
-                                        }
+                                        onClick={restartInformJob}
                                     >
                                         {intl.formatMessage(
                                             { id: "tickets.action.restart_inform_job" },

--- a/src/custom-surf/types.ts
+++ b/src/custom-surf/types.ts
@@ -80,6 +80,8 @@ export interface ServiceTicketLog {
     update_en: string;
     log_type: ServiceTicketLogType;
     logged_by: string;
+    transition: ServiceTicketTransition;
+    completed: boolean;
 }
 
 export enum ServiceTicketImpactedObjectImpact {

--- a/src/custom-surf/types.ts
+++ b/src/custom-surf/types.ts
@@ -141,6 +141,7 @@ export interface BackgroundJobLog {
     subscription_id?: string;
     entry_time: string;
     process_state: string;
+    context: object;
 }
 
 export interface Email {

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -529,7 +529,9 @@ I18n.translations.en = {
         },
         action: {
             background_job_restarted: "Restarted background job",
+            inform_job_restarted: "Started inform job recovery",
             restart_open_relate: "Restart open relate",
+            restart_inform_job: "Recover {{inform_job}}",
             open_and_close: "Send OPEN & CLOSE email",
             opening: "Send OPEN email",
             updating: "Send UPDATE email",


### PR DESCRIPTION
Surf specific changes for `cim#44`:
* Add feature to recover a failed inform job (extended `ServiceTicketLog` and `BackgroundJobLog`)
* Enhance background logs (show more context, make sortable)
* Don't show a popup when a service ticket refresh fails
