### PR TITLE
Get cache options from API, display delete count

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -332,7 +332,11 @@ export class ApiClient extends ApiClientInterface {
         return this.postPutJson("user/error", error, "post", false);
     };
 
-    clearCache = (name: string) => {
+    getCacheNames = (): Promise<Record<string, string>> => {
+        return this.fetchJson("settings/cache-names");
+    };
+
+    clearCache = (name: string): Promise<number | null> => {
         return this.postPutJson(`settings/cache/${name}`, {}, "delete", true, false);
     };
 

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -744,7 +744,7 @@ I18n.translations.en = {
             remove: "Flush Settings",
             remove_info: "Select settings to flush",
             clear: "Flush",
-            flushed: "Settings {{name}} was flushed",
+            flushed: "Settings {{name}} was flushed (deleted: {{count}})",
         },
         status: {
             info: "Modify the engine settings",


### PR DESCRIPTION
* Use new endpoint `/cache-names` to retrieve possible caches to delete
* Display the number of deleted cache keys