### PR TITLE
CIM fixes/usability

### DIFF
--- a/src/custom-surf/api/index.ts
+++ b/src/custom-surf/api/index.ts
@@ -231,6 +231,9 @@ export class CustomApiClient extends CustomApiClientInterface {
     cimCreateTicket = (ticket: CreateServiceTicketPayload): Promise<{ id: string }> => {
         return this.postPutJson(prefix_cim_dev_uri("surf/cim/tickets"), ticket, "post", false, true);
     };
+    cimDeleteTicket = (ticket_id: string): Promise<null> => {
+        return this.postPutJson(prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}`), {}, "delete", false);
+    };
 
     /* TODO cim#50 reduce api boilerplate */
     cimAcceptTicket = (ticket_id: string): Promise<ServiceTicketWithDetails> => {

--- a/src/custom-surf/pages/ServiceTickets.tsx
+++ b/src/custom-surf/pages/ServiceTickets.tsx
@@ -61,14 +61,13 @@ class ServiceTickets extends React.PureComponent<IProps, IState> {
         serviceTickets: [],
         query: "",
         searchResults: [],
-        sortOrder: { name: "jira_ticket_id", descending: false },
+        sortOrder: { name: "last_update_time", descending: true },
         filterAttributes: {
             state: Object.values(ServiceTicketProcessState)
                 .filter((s) => s)
                 .map((state) => ({
                     name: state ?? "",
-                    // selected: state === ServiceTicketProcessState.OPEN,
-                    selected: false,
+                    selected: ![ServiceTicketProcessState.ABORTED, ServiceTicketProcessState.CLOSED].includes(state),
                     count: 0,
                 })),
         },

--- a/src/custom-surf/pages/ServiceTickets.tsx
+++ b/src/custom-surf/pages/ServiceTickets.tsx
@@ -5,6 +5,7 @@
 
 import {
     EuiButton,
+    EuiButtonIcon,
     EuiFacetButton,
     EuiFlexGroup,
     EuiFlexItem,
@@ -25,6 +26,7 @@ import { FormattedMessage, WrappedComponentProps, injectIntl } from "react-intl"
 import { Link } from "react-router-dom";
 import ScrollUpButton from "react-scroll-up-button";
 import ApplicationContext from "utils/ApplicationContext";
+import { setFlash } from "utils/Flash";
 import { Filter, SortOption } from "utils/types";
 import { isEmpty, stop } from "utils/Utils";
 
@@ -234,6 +236,19 @@ class ServiceTickets extends React.PureComponent<IProps, IState> {
         return <i />;
     };
 
+    deleteTicket = async (ticket_id: string) => {
+        try {
+            await this.context.customApiClient.cimDeleteTicket(ticket_id);
+        } catch (error: any) {
+            if (error.response.status === 400) {
+                setFlash(error.response.data.detail, "error");
+            } else {
+                throw error;
+            }
+        }
+        this.refreshData();
+    };
+
     render() {
         const columns: Column[] = [
             "jira_ticket_id",
@@ -364,6 +379,17 @@ class ServiceTickets extends React.PureComponent<IProps, IState> {
                                         className="updated_on"
                                     >
                                         {renderIsoDatetime(ticket.last_update_time, true)}
+                                    </td>
+                                    <td>
+                                        {ticket.process_state === ServiceTicketProcessState.NEW &&
+                                            !ticket.transition_action && (
+                                                <EuiButtonIcon
+                                                    id={`tickets.table.${ticket._id}.delete`}
+                                                    iconType="trash"
+                                                    aria-label={intl.formatMessage({ id: "tickets.table.delete" })}
+                                                    onClick={() => this.deleteTicket(ticket._id)}
+                                                />
+                                            )}
                                     </td>
                                 </tr>
                             ))}

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -549,6 +549,7 @@ I18n.translations.en = {
             ims_circuit_name: "IMS Name",
             ims_circuit_id: "ID",
             extra_information: "Extra info",
+            extra_info: "Extra info",
             impact_override: "Override",
             impact_override_info: "Use this to override the impact, or clear to remove override",
         },

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -526,6 +526,7 @@ I18n.translations.en = {
             last_update_time: "Updated on",
             type: "Type",
             transition_action: "Transitioning",
+            delete: "Delete ticket",
         },
         action: {
             background_job_restarted: "Restarted background job",


### PR DESCRIPTION
Surf specific (cim)
* Add button to delete tickets stuck in state `NEW` when there is no active background job
* Sort tickets table by last update time (desc) & hide aborted/closed tickets in the default filter
* Translation fixes