### PR TITLE
Fix form resetting when process updates

### DIFF
--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -74,6 +74,7 @@ function ProcessDetail({ match, query, setQuery }: IProps) {
     });
 
     const handleUpdateProcess = (processInstance: ProcessWithDetails) => {
+        if (stepUserInput) return;
         const localStepUserInput: InputForm | undefined = processInstance.form;
         const localTabs = localStepUserInput ? ["user_input", "process"] : ["process"];
         const localSelectedTab = localStepUserInput ? "user_input" : "process";
@@ -353,6 +354,7 @@ function ProcessDetail({ match, query, setQuery }: IProps) {
         }
 
         return apiClient.resumeProcess(process.id, processInput).then(() => {
+            setStepUserInput(undefined);
             setFlash(
                 intl.formatMessage(
                     { id: `${process.is_task ? "task" : "process"}.flash.update` },

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -74,8 +74,8 @@ function ProcessDetail({ match, query, setQuery }: IProps) {
     });
 
     const handleUpdateProcess = (processInstance: ProcessWithDetails) => {
-        if (stepUserInput) return;
         const localStepUserInput: InputForm | undefined = processInstance.form;
+        if (stepUserInput && localStepUserInput) return;
         const localTabs = localStepUserInput ? ["user_input", "process"] : ["process"];
         const localSelectedTab = localStepUserInput ? "user_input" : "process";
 


### PR DESCRIPTION
The detail page stops updating when there is a form so it doesn't reset.
If the form is handled, the detail page does update for other instances.

This is mostly caused by httpFallback that triggers every 3 seconds, tried checking if the data even needs to be updated, but somehow the `process` isn't ever the same as the `processInstance` it is updated with at line 84