### PR TITLE
Fix displaying multiple resource-type values

### DIFF
--- a/src/components/subscriptionDetail/templates/ServiceConfiguration.tsx
+++ b/src/components/subscriptionDetail/templates/ServiceConfiguration.tsx
@@ -67,7 +67,7 @@ export const mapSplitFields = (
                 return [key, values];
             }
 
-            return [key, values[0]];
+            return [key, values.join(", ")];
         })
         .map(([key, values]) => {
             if (key === "in_use_by_ids" && values) {


### PR DESCRIPTION
Join resource-type value array to a string, fixes displaying multiple values