### PR TITLE
feat: add styling to pretty print dry run in the process state

### DIFF
--- a/src/components/ProcessStateDetailsStyling.ts
+++ b/src/components/ProcessStateDetailsStyling.ts
@@ -114,6 +114,7 @@ export const processStateDetailsStyling = css`
                                 width: 800px;
                                 min-width: 550px;
                                 padding-left: 20px;
+                                white-space: pre-wrap;
                             }
                             pre {
                                 margin-left: -10px;


### PR DESCRIPTION
This PR adds CSS styling to pretty-print dry-run results in the process tab, ie:

<img width="1238" alt="Screen Shot 2023-05-04 at 12 32 08 PM" src="https://user-images.githubusercontent.com/17922874/236310709-7f144718-98f3-4d8d-a3f9-8e97c4413c0d.png">
