### PR TITLE
Add card for worker status to settings page

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -24,6 +24,7 @@ import {
     Subscription,
     SubscriptionModel,
     SubscriptionProcesses,
+    WorkerStatus,
     Workflow,
     WorkflowReasons,
     WorkflowWithProductTags,
@@ -346,6 +347,10 @@ export class ApiClient extends ApiClientInterface {
 
     setGlobalStatus = (new_global_lock: boolean) => {
         return this.postPutJson("settings/status", { global_lock: new_global_lock }, "put");
+    };
+
+    getWorkerStatus = (): Promise<WorkerStatus> => {
+        return this.fetchJson("settings/worker-status", {}, {}, false);
     };
 
     logUserInfo = (username: string, message: string) => {

--- a/src/contextProviders/engineSettingsProvider/index.tsx
+++ b/src/contextProviders/engineSettingsProvider/index.tsx
@@ -28,14 +28,14 @@ interface WsEngineStatus {
     "engine-status": EngineStatus;
 }
 
-const defaultEngineSettings: EngineStatus = {
+const defaultEngineStatus: EngineStatus = {
     global_lock: false,
     running_processes: 0,
     global_status: "RUNNING",
 };
 
 const EngineSettingsContext = createContext<EngineSettingsContextData>({
-    engineStatus: defaultEngineSettings,
+    engineStatus: defaultEngineStatus,
     useFallback: false,
 });
 
@@ -45,11 +45,7 @@ export default EngineSettingsContext;
 export function EngineSettingsContextWrapper({ children }: any) {
     const { apiClient } = useContext(ApplicationContext);
     const { lastMessage, useFallback } = useWebsocketService<WsEngineStatus>("api/settings/ws-status/");
-    const [engineStatus, setEngineStatus] = useState<EngineStatus>({
-        global_lock: false,
-        running_processes: 0,
-        global_status: "RUNNING",
-    });
+    const [engineStatus, setEngineStatus] = useState<EngineStatus>(defaultEngineStatus);
 
     const getEngineStatus = useCallback(() => {
         apiClient.getGlobalStatus().then((newEngineStatus) => {

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -771,7 +771,7 @@ I18n.translations.en = {
             number_of_workers_online: "# workers online:",
             number_of_running_jobs: "# running jobs:",
             number_of_queued_jobs: "# queued jobs:",
-        }
+        },
     },
     error_dialog: {
         title: "Unexpected error",

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -764,6 +764,14 @@ I18n.translations.en = {
                 restarted: "The engine has been restarted",
             },
         },
+        worker_status: {
+            info: "Worker status:",
+            info_detail: "Info on workers and jobs:",
+            executor_type: "Executor type:",
+            number_of_workers_online: "# workers online:",
+            number_of_running_jobs: "# running jobs:",
+            number_of_queued_jobs: "# queued jobs:",
+        }
     },
     error_dialog: {
         title: "Unexpected error",

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -144,10 +144,13 @@ export interface SubscriptionWithDetails extends Subscription {
     customer_descriptions: CustomerDescription[];
     tag: string;
 }
+
 export interface SubscriptionModel extends Subscription {
     customer_descriptions: CustomerDescription[];
+
     [index: string]: any;
 }
+
 export interface IpPrefixSubscription extends Subscription {
     id: number;
     prefix: string;
@@ -315,6 +318,7 @@ export interface Workflow {
 export interface WorkflowWithProductTags extends Workflow {
     product_tags: string[];
 }
+
 export interface CodedWorkflow {
     name: string;
     implementation: string;
@@ -374,6 +378,7 @@ export interface IMSEndpoint {
     port: string;
     status: string;
 }
+
 export interface IMSService {
     id: number;
     customer_id: string;
@@ -417,6 +422,13 @@ export interface WorkflowReasons {
 }
 
 export type GlobalStatus = "RUNNING" | "PAUSED" | "PAUSING";
+
+export interface WorkerStatus {
+    executor_type: string;
+    number_of_workers_online: number;
+    number_of_queued_jobs: number;
+    number_of_running_jobs: number;
+}
 
 export interface EngineStatus {
     global_lock: boolean;
@@ -491,6 +503,7 @@ export interface ISubscriptionInstance {
     owner_subscription_id: string;
     name: string;
     label?: string;
+
     [index: string]: any;
 }
 


### PR DESCRIPTION
Uses `/api/settings/worker-status` endpoint and shows info in the settings page