### PR TITLE
Consistent custompage route order

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -378,14 +378,16 @@ class App extends React.PureComponent<IProps, IState> {
                                                     )}
 
                                                     {!isEmpty(importedModules) &&
-                                                        importedModules.map(({ path, name, Component }) => (
-                                                            <Route
-                                                                key={path}
-                                                                exact
-                                                                path={`/${name}`}
-                                                                component={Component}
-                                                            />
-                                                        ))}
+                                                        importedModules
+                                                            .sort((a, b) => a.page_order - b.page_order) // Ensure page-routes are matched in same order as manifest
+                                                            .map(({ path, name, Component }) => (
+                                                                <Route
+                                                                    key={path}
+                                                                    exact
+                                                                    path={`/${name}`}
+                                                                    component={Component}
+                                                                />
+                                                            ))}
 
                                                     <ProtectedRoute path="/new-task" render={() => <NewTask />} />
 


### PR DESCRIPTION
While the order of `importedModules`is guaranteed, the order of `importedModules.map(...)` isn't. 

As a result the app will _sometimes_ define (and thus match) `<Route>` components in a wrong order.

The added `.sort()` call ensures a consistent order.