### PR TITLE
CIM: 404 handling, back button

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -47,6 +47,7 @@ export class BaseApiClient {
             .then((res) => res.data)
             .catch((err) => {
                 if (showErrorDialog) {
+                    console.debug(`Show error dialog for GET ${path} returning ${err?.response?.status}`);
                     setTimeout(() => {
                         throw err;
                     }, 250);

--- a/src/custom-surf/api/index.ts
+++ b/src/custom-surf/api/index.ts
@@ -313,7 +313,10 @@ export class CustomApiClient extends CustomApiClientInterface {
 
     cimGetAllowedTransitions = (ticket_id: string): Promise<ServiceTicketTransition[]> => {
         return this.fetchJson<ServiceTicketTransition[]>(
-            prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/transitions`)
+            prefix_cim_dev_uri(`surf/cim/tickets/${ticket_id}/transitions`),
+            {},
+            {},
+            false
         );
     };
 

--- a/src/custom-surf/pages/ServiceTicketMails.tsx
+++ b/src/custom-surf/pages/ServiceTicketMails.tsx
@@ -53,7 +53,7 @@ const ServiceTicketMails = () => {
 
     const [items, setItems] = useState<EmailLogWithId[]>([]);
     const [ticket, setTicket] = useState<ServiceTicketWithDetails>();
-    const { customApiClient } = useContext(ApplicationContext);
+    const { customApiClient, redirect } = useContext(ApplicationContext);
 
     const { isLoading, error } = useQuery<ServiceTicketWithDetails, Error>(
         ["ticket", { id: id }],
@@ -155,6 +155,11 @@ const ServiceTicketMails = () => {
                             ></EuiButtonIcon>
                         </EuiFlexItem>
 
+                        <EuiFlexItem grow={false}>
+                            <EuiButton size="m" onClick={() => redirect(`/tickets/${id}`)} iconType="editorUndo">
+                                Back
+                            </EuiButton>
+                        </EuiFlexItem>
                         <EuiFlexItem grow={false} style={{ minWidth: 140 }}>
                             <EuiButton
                                 isSelected={!showHtml}

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -486,7 +486,7 @@ I18n.translations.en = {
         copy: "Copy to clipboard",
     },
     tickets: {
-        notFound: "No Ticket found (e.g. 404)",
+        notFound: "Ticket not found",
         create: {
             new_ticket: "New Service Ticket",
             create: "Create new Service ticket",


### PR DESCRIPTION
CIM changes:
* fix serviceticket detail showing 'unexpected error' popup instead of a 'Ticket not found' page
* don't fetch ticket transitions when there is no ticket
* add "back" button on Last Sent Emails page