### PR TITLE
Add modal to process table

### DIFF
--- a/src/components/modals/ProcessTableCellModal.tsx
+++ b/src/components/modals/ProcessTableCellModal.tsx
@@ -1,55 +1,44 @@
+import { EuiButton, EuiModal, EuiModalBody, EuiModalFooter, EuiModalHeader, EuiModalHeaderTitle } from "@elastic/eui";
 import React, { useState } from "react";
-import {
-  EuiModal,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiButton,
-} from "@elastic/eui";
 
 type ModalInterface = {
-  title: string;
-  buttonTitle: string;
-  children: React.ReactNode;
+    title: string;
+    buttonTitle: string;
+    children: React.ReactNode;
 };
 
-const ProcessTableModal = ({
-  title = "",
-  buttonTitle = "Show Modal",
-  children,
-}: ModalInterface) => {
-  const [isModalVisible, setIsModalVisible] = useState(false);
+const ProcessTableModal = ({ title = "", buttonTitle = "Show Modal", children }: ModalInterface) => {
+    const [isModalVisible, setIsModalVisible] = useState(false);
 
-  const closeModal = () => setIsModalVisible(false);
-  const showModal = () => setIsModalVisible(true);
+    const closeModal = () => setIsModalVisible(false);
+    const showModal = () => setIsModalVisible(true);
 
-  let modal;
+    let modal;
 
-  if (isModalVisible) {
-    modal = (
-      <EuiModal onClose={closeModal}>
-        <EuiModalHeader>
-          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
-        </EuiModalHeader>
+    if (isModalVisible) {
+        modal = (
+            <EuiModal onClose={closeModal}>
+                <EuiModalHeader>
+                    <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+                </EuiModalHeader>
 
-        <EuiModalBody>{children}</EuiModalBody>
+                <EuiModalBody>{children}</EuiModalBody>
 
-        <EuiModalFooter>
-          <EuiButton onClick={closeModal} fill>
-            Close
-          </EuiButton>
-        </EuiModalFooter>
-      </EuiModal>
+                <EuiModalFooter>
+                    <EuiButton onClick={closeModal} fill>
+                        Close
+                    </EuiButton>
+                </EuiModalFooter>
+            </EuiModal>
+        );
+    }
+
+    return (
+        <div>
+            <EuiButton onClick={showModal}>{buttonTitle}</EuiButton>
+            {modal}
+        </div>
     );
-  }
-
-  return (
-    <div>
-      <EuiButton onClick={showModal}>{buttonTitle}</EuiButton>
-      {modal}
-    </div>
-  );
 };
 
 export default ProcessTableModal;

--- a/src/components/modals/ProcessTableCellModal.tsx
+++ b/src/components/modals/ProcessTableCellModal.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiButton,
+} from "@elastic/eui";
+
+type ModalInterface = {
+  title: string;
+  buttonTitle: string;
+  children: React.ReactNode;
+};
+
+const ProcessTableModal = ({
+  title = "",
+  buttonTitle = "Show Modal",
+  children,
+}: ModalInterface) => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  const closeModal = () => setIsModalVisible(false);
+  const showModal = () => setIsModalVisible(true);
+
+  let modal;
+
+  if (isModalVisible) {
+    modal = (
+      <EuiModal onClose={closeModal}>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+        </EuiModalHeader>
+
+        <EuiModalBody>{children}</EuiModalBody>
+
+        <EuiModalFooter>
+          <EuiButton onClick={closeModal} fill>
+            Close
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiModal>
+    );
+  }
+
+  return (
+    <div>
+      <EuiButton onClick={showModal}>{buttonTitle}</EuiButton>
+      {modal}
+    </div>
+  );
+};
+
+export default ProcessTableModal;

--- a/src/components/tables/cellRenderers.tsx
+++ b/src/components/tables/cellRenderers.tsx
@@ -14,12 +14,12 @@
  */
 
 import { EuiListGroup } from "@elastic/eui";
+import ProcessTableModal from "components/modals/ProcessTableCellModal";
 import { intl } from "locale/i18n";
 import uniq from "lodash/uniq";
 import { Link } from "react-router-dom";
 import { Cell } from "react-table";
 import { Organization, Product, Subscription } from "utils/types";
-import ProcessTableModal from "components/modals/ProcessTableCellModal";
 
 const LIST_MAX_LENGTH = 3; // Max length of lists before they're converted to modals
 
@@ -31,64 +31,60 @@ const LIST_MAX_LENGTH = 3; // Max length of lists before they're converted to mo
  * @returns a properly formatted title
  */
 const _formatModalButtonTitle = (title: string) => {
-  return `${title.replace("(s)", "")}(s)`;
+    return `${title.replace("(s)", "")}(s)`;
 };
 
 export function renderSubscriptionsCell({ cell }: { cell: Cell }) {
-  const subscriptions: Subscription[] = cell.value;
-  const { Header } = cell?.column;
-  const subscriptionList = (
-    <EuiListGroup
-      listItems={subscriptions.map((subscription: Subscription) => {
-        return {
-          label: subscription.description,
-          href: `/subscriptions/${subscription.subscription_id}`,
-        };
-      })}
-      color="primary"
-      size="s"
-    />
-  );
+    const subscriptions: Subscription[] = cell.value;
+    const { Header } = cell?.column;
+    const subscriptionList = (
+        <EuiListGroup
+            listItems={subscriptions.map((subscription: Subscription) => {
+                return {
+                    label: subscription.description,
+                    href: `/subscriptions/${subscription.subscription_id}`,
+                };
+            })}
+            color="primary"
+            size="s"
+        />
+    );
 
-  return subscriptions.length > LIST_MAX_LENGTH ? (
-    <ProcessTableModal
-      title={`${Header}`}
-      buttonTitle={_formatModalButtonTitle(
-        `Show ${subscriptions.length} ${Header}`
-      )}
-    >
-      {subscriptionList}
-    </ProcessTableModal>
-  ) : (
-    <>{subscriptionList}</>
-  );
+    return subscriptions.length > LIST_MAX_LENGTH ? (
+        <ProcessTableModal
+            title={`${Header}`}
+            buttonTitle={_formatModalButtonTitle(`Show ${subscriptions.length} ${Header}`)}
+        >
+            {subscriptionList}
+        </ProcessTableModal>
+    ) : (
+        <>{subscriptionList}</>
+    );
 }
 
 export function renderProductsCell({ cell }: { cell: Cell }) {
-  const subscriptions: Subscription[] = cell.value;
-  const { Header } = cell?.column;
-  const productNames = uniq(
-    subscriptions.map((subscription: Subscription) => subscription.product.name)
-  ).map((product_name, idx) => {
-    return {
-      label: product_name,
-    };
-  });
+    const subscriptions: Subscription[] = cell.value;
+    const { Header } = cell?.column;
+    const productNames = uniq(subscriptions.map((subscription: Subscription) => subscription.product.name)).map(
+        (product_name, idx) => {
+            return {
+                label: product_name,
+            };
+        }
+    );
 
-  const productNamesList = <EuiListGroup listItems={productNames} size="s" />;
+    const productNamesList = <EuiListGroup listItems={productNames} size="s" />;
 
-  return productNames.length > LIST_MAX_LENGTH ? (
-    <ProcessTableModal
-      title={`${Header}`}
-      buttonTitle={_formatModalButtonTitle(
-        `Show ${productNames.length} ${Header}`
-      )}
-    >
-      {productNamesList}
-    </ProcessTableModal>
-  ) : (
-    <>{productNamesList}</>
-  );
+    return productNames.length > LIST_MAX_LENGTH ? (
+        <ProcessTableModal
+            title={`${Header}`}
+            buttonTitle={_formatModalButtonTitle(`Show ${productNames.length} ${Header}`)}
+        >
+            {productNamesList}
+        </ProcessTableModal>
+    ) : (
+        <>{productNamesList}</>
+    );
 }
 
 export function renderSubscriptionProductsCell({ cell }: { cell: Cell }) {
@@ -97,52 +93,42 @@ export function renderSubscriptionProductsCell({ cell }: { cell: Cell }) {
 }
 
 export function renderCustomersCell(organisations: Organization[] | null | undefined, abbreviate: boolean) {
-  function lookup(uuid: string) {
-    if (organisations === null || organisations === undefined) {
-      return intl.formatMessage({
-        id: abbreviate ? "unavailable_abbreviated" : "unavailable",
-      });
+    function lookup(uuid: string) {
+        if (organisations === null || organisations === undefined) {
+            return intl.formatMessage({
+                id: abbreviate ? "unavailable_abbreviated" : "unavailable",
+            });
+        }
+        const organisation: Organization | undefined = organisations.find((org) => org.uuid === uuid);
+        return organisation ? (abbreviate ? organisation.abbr : organisation.name) : uuid;
     }
-    const organisation: Organization | undefined = organisations.find(
-      (org) => org.uuid === uuid
-    );
-    return organisation
-      ? abbreviate
-        ? organisation.abbr
-        : organisation.name
-      : uuid;
-  }
 
-  return function doRenderCustomersCell({ cell }: { cell: Cell }) {
-    const subscriptions: Subscription[] = cell.value;
-    const { Header } = cell?.column;
-    const customerIds = uniq(
-      subscriptions.map((subscription) => subscription.customer_id)
-    ).map(lookup);
-    const customerIdsList = (
-      <EuiListGroup
-        listItems={customerIds.map((customerId) => {
-          return {
-            label: customerId,
-          };
-        })}
-        size="s"
-      />
-    );
+    return function doRenderCustomersCell({ cell }: { cell: Cell }) {
+        const subscriptions: Subscription[] = cell.value;
+        const { Header } = cell?.column;
+        const customerIds = uniq(subscriptions.map((subscription) => subscription.customer_id)).map(lookup);
+        const customerIdsList = (
+            <EuiListGroup
+                listItems={customerIds.map((customerId) => {
+                    return {
+                        label: customerId,
+                    };
+                })}
+                size="s"
+            />
+        );
 
-    return customerIds.length > LIST_MAX_LENGTH ? (
-      <ProcessTableModal
-        title={`${Header}`}
-        buttonTitle={_formatModalButtonTitle(
-          `Show ${customerIds.length} ${Header}`
-        )}
-      >
-        {customerIdsList}
-      </ProcessTableModal>
-    ) : (
-      <>{customerIdsList}</>
-    );
-  };
+        return customerIds.length > LIST_MAX_LENGTH ? (
+            <ProcessTableModal
+                title={`${Header}`}
+                buttonTitle={_formatModalButtonTitle(`Show ${customerIds.length} ${Header}`)}
+            >
+                {customerIdsList}
+            </ProcessTableModal>
+        ) : (
+            <>{customerIdsList}</>
+        );
+    };
 }
 
 export function renderSubscriptionCustomersCell(organisations: Organization[] | null | undefined, abbreviate: boolean) {

--- a/src/components/tables/cellRenderers.tsx
+++ b/src/components/tables/cellRenderers.tsx
@@ -230,11 +230,30 @@ export function renderInsyncCell({ cell }: { cell: Cell }) {
 
 export function renderProductTagCell({ cell }: { cell: Cell }) {
     const subscriptions: Subscription[] = cell.value;
-    return uniq(
+    const { Header } = cell?.column;
+    const tags = uniq(
         subscriptions.map((subscription: Subscription) => {
             return subscription.product.tag;
         })
-    ).join(", ");
+    );
+    const tagsList = (
+        <EuiListGroup
+            listItems={tags.map((tag) => {
+                return {
+                    label: tag,
+                };
+            })}
+            size="s"
+        />
+    );
+
+    return tags.length > LIST_MAX_LENGTH ? (
+        <ProcessTableModal title={`${Header}`} buttonTitle={_formatModalButtonTitle(`Show ${tags.length} ${Header}`)}>
+            {tagsList}
+        </ProcessTableModal>
+    ) : (
+        <>{tagsList}</>
+    );
 }
 
 export function renderSubscriptionTagCell({ cell }: { cell: Cell }) {

--- a/src/components/tables/cellRenderers.tsx
+++ b/src/components/tables/cellRenderers.tsx
@@ -17,6 +17,7 @@ import { EuiListGroup } from "@elastic/eui";
 import ProcessTableModal from "components/modals/ProcessTableCellModal";
 import { intl } from "locale/i18n";
 import uniq from "lodash/uniq";
+import moment from "moment-timezone";
 import { Link } from "react-router-dom";
 import { Cell } from "react-table";
 import { Organization, Product, Subscription } from "utils/types";
@@ -146,23 +147,22 @@ export function renderSubscriptionCustomersCell(organisations: Organization[] | 
     };
 }
 
-export function renderTimestampCell({ cell }: { cell: Cell }) {
+export function renderTimestampCell({ cell }: { cell: Cell }): string | null {
+    // Convert timestamp to ISO8601-like format.
+    // Example:
+    //   2023-07-12 15:16:32 CEST
+    // if the date is in the past, only the ISO date string will be returned.
     if (!cell.value) {
         return null;
     }
-    const timestamp: number = cell.value;
+    // get milliseconds for unix timestamp
+    const time = moment(cell.value * 1000);
+    // get timezone from translations object
+    const timezone = intl.formatMessage({ id: "locale.timezone" });
+    // if time is more than 24hr ago, show only date string
+    const format = moment().diff(time, "hours") >= 24 ? "y-MM-DD" : "y-MM-DD HH:mm:ss z";
 
-    const datetime = new Date(timestamp * 1000);
-    const today = new Date();
-    if (
-        datetime.getFullYear() === today.getFullYear() &&
-        datetime.getMonth() === today.getMonth() &&
-        datetime.getDay() === today.getDay()
-    ) {
-        return datetime.toLocaleTimeString("nl-NL").substring(0, 5) + " CET";
-    } else {
-        return datetime.toLocaleDateString("nl-NL");
-    }
+    return time.tz(timezone).format(format);
 }
 
 export function renderPidCell({ cell }: { cell: Cell }) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -32,6 +32,7 @@ interface Env {
     CI_MERGE_REQUEST_IID: string;
     GITLAB_URL: string;
     CI_PROJECT_PATH: string;
+    LOCALE: string;
 }
 
 // We normally load env from window.__env__ as defined in public/env.js which
@@ -61,4 +62,5 @@ export const ENV: Env = window.__env__ || {
     CI_MERGE_REQUEST_IID: process.env.REACT_APP_CI_MERGE_REQUEST_IID,
     GITLAB_URL: process.env.REACT_APP_GITLAB_URL,
     CI_PROJECT_PATH: process.env.REACT_APP_CI_PROJECT_PATH,
+    LOCALE: process.env.REACT_APP_LOCALE || "en-GB",
 };

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -921,6 +921,9 @@ I18n.translations.en = {
             close_ticket_form: "Close ticket form submitted",
         },
     },
+    locale: {
+        timezone: "Europe/Amsterdam",
+    },
 };
 
 export default I18n.translations.en;

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -1,3 +1,4 @@
+import { ENV } from "env";
 import en from "locale/en";
 import { merge } from "lodash";
 import { createIntl, createIntlCache } from "react-intl";
@@ -26,7 +27,7 @@ async function loadLocaleData(locale: string): Promise<Record<string, string>> {
             break;
     }
 
-    messages = merge(backend_messages, messages);
+    messages = merge(messages, backend_messages);
 
     return parse_translations_dict(messages);
 }
@@ -41,8 +42,10 @@ function parse_from_object(
 
         if (typeof msg === "object" && msg !== null) {
             parse_from_object(results, prefixed_id, msg);
-        } else {
+        } else if (typeof msg == "string") {
             results[prefixed_id] = msg.replace(/\{\{/g, "{").replace(/\}\}/g, "}");
+        } else {
+            results[prefixed_id] = msg;
         }
     }
 }
@@ -63,7 +66,7 @@ const cache = createIntlCache();
 export let intl = createIntl(
     {
         // Locale of the application
-        locale: "en-GB",
+        locale: ENV.LOCALE,
         // Locale of the fallback defaultMessage
         defaultLocale: "en-GB",
         messages: parse_translations_dict(en),
@@ -76,7 +79,7 @@ export async function setLocale(locale: string) {
     intl = createIntl(
         {
             // Locale of the application
-            locale: locale,
+            locale: ENV.LOCALE,
             // Locale of the fallback defaultMessage
             defaultLocale: "en-GB",
             messages: await loadLocaleData(locale),

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -208,11 +208,13 @@ class App extends React.PureComponent<IProps, IState> {
             this.state.applicationContext.apiClient.products(),
             this.state.applicationContext.apiClient.assignees(),
             this.state.applicationContext.apiClient.processStatuses(),
-            setLocale("en-GB"),
+            setLocale(intl.locale),
             createPolicyCheck(this.props.user),
         ]);
 
-        const filteredProducts = (allProducts || []).sort((a, b) => a.name.localeCompare(b.name));
+        const filteredProducts = (allProducts || []).sort((a: { name: string }, b: { name: any }) =>
+            a.name.localeCompare(b.name)
+        );
 
         this.setState({
             loading: false,


### PR DESCRIPTION
For Processes which can modify/touch multiple Subscriptions (a rare and non-standard case), the ProcessTable component's default rendering style is to join an `EuiFlexGroup` of `Link`s with a forward slash (`/`).

This works for one or two `<Link>` components, but quickly breaks with more than three.

This MR moves any group of cell data with more than 3 items into a scrollable `Modal` component for legibility.