### PR TITLE
Fix hard coded timezone

### DIFF
--- a/src/components/tables/cellRenderers.tsx
+++ b/src/components/tables/cellRenderers.tsx
@@ -14,8 +14,8 @@
  */
 
 import { EuiListGroup } from "@elastic/eui";
-import { ENV } from "env";
 import { intl } from "locale/i18n";
+import moment from "moment-timezone";
 import uniq from "lodash/uniq";
 import { Link } from "react-router-dom";
 import { Cell } from "react-table";
@@ -169,28 +169,14 @@ export function renderTimestampCell({ cell }: { cell: Cell }) : string | null {
     if (!cell.value) {
         return null;
     }
-    const utc_timestamp: number = cell.value;
-    const PFX = "locale.options.";
-    const options: Record<string, string | boolean> = {"hour12": false};
+    // get milliseconds for unix timestamp
+    const time = moment(cell.value * 1000);
+    // get timezone from translations object
+    const timezone = intl.formatMessage({id: "locale.timezone"});
+    // if time is more than 24hr ago, show only date string
+    const format = moment().diff(time, "hours") >= 24 ? "y-MM-DD" : "y-MM-DD HH:mm:ss z";
 
-    // map all locale.options into an object to pass to Date()
-    ["timeZone", "timeZoneName", "hour", "minute", "second"].forEach((key) => {
-            options[key] = intl.formatMessage({id: PFX + key})
-        }
-    )
-
-    const datetime = new Date(utc_timestamp * 1000);
-    const dateString = datetime.toISOString().split("T")[0];
-    const today = new Date();
-    if (
-        datetime.getFullYear() === today.getFullYear() &&
-        datetime.getMonth() === today.getMonth() &&
-        datetime.getDay() === today.getDay()
-    ) {
-        return dateString + " " + datetime.toLocaleTimeString(ENV.LOCALE, options)
-    } else {
-        return dateString
-    }
+    return time.tz(timezone).format(format)
 }
 
 export function renderPidCell({ cell }: { cell: Cell }) {

--- a/src/components/tables/cellRenderers.tsx
+++ b/src/components/tables/cellRenderers.tsx
@@ -16,8 +16,8 @@
 import { EuiListGroup } from "@elastic/eui";
 import ProcessTableModal from "components/modals/ProcessTableCellModal";
 import { intl } from "locale/i18n";
-import moment from "moment-timezone";
 import uniq from "lodash/uniq";
+import moment from "moment-timezone";
 import { Link } from "react-router-dom";
 import { Cell } from "react-table";
 import { Organization, Product, Subscription } from "utils/types";
@@ -147,7 +147,7 @@ export function renderSubscriptionCustomersCell(organisations: Organization[] | 
     };
 }
 
-export function renderTimestampCell({ cell }: { cell: Cell }) : string | null {
+export function renderTimestampCell({ cell }: { cell: Cell }): string | null {
     // Convert timestamp to ISO8601-like format.
     // Example:
     //   2023-07-12 15:16:32 CEST
@@ -158,11 +158,11 @@ export function renderTimestampCell({ cell }: { cell: Cell }) : string | null {
     // get milliseconds for unix timestamp
     const time = moment(cell.value * 1000);
     // get timezone from translations object
-    const timezone = intl.formatMessage({id: "locale.timezone"});
+    const timezone = intl.formatMessage({ id: "locale.timezone" });
     // if time is more than 24hr ago, show only date string
     const format = moment().diff(time, "hours") >= 24 ? "y-MM-DD" : "y-MM-DD HH:mm:ss z";
 
-    return time.tz(timezone).format(format)
+    return time.tz(timezone).format(format);
 }
 
 export function renderPidCell({ cell }: { cell: Cell }) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -32,6 +32,7 @@ interface Env {
     CI_MERGE_REQUEST_IID: string;
     GITLAB_URL: string;
     CI_PROJECT_PATH: string;
+    LOCALE: string;
 }
 
 // We normally load env from window.__env__ as defined in public/env.js which
@@ -61,4 +62,5 @@ export const ENV: Env = window.__env__ || {
     CI_MERGE_REQUEST_IID: process.env.REACT_APP_CI_MERGE_REQUEST_IID,
     GITLAB_URL: process.env.REACT_APP_GITLAB_URL,
     CI_PROJECT_PATH: process.env.REACT_APP_CI_PROJECT_PATH,
+    LOCALE: process.env.REACT_APP_LOCALE || "en-GB",
 };

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -923,7 +923,7 @@ I18n.translations.en = {
     },
     locale: {
         timezone: "Europe/Amsterdam",
-    }
+    },
 };
 
 export default I18n.translations.en;

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -921,6 +921,16 @@ I18n.translations.en = {
             close_ticket_form: "Close ticket form submitted",
         },
     },
+    locale: {
+        options: {
+            timeZone: "Europe/Amsterdam",
+            timeZoneName: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hour12: false,
+        }
+    }
 };
 
 export default I18n.translations.en;

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -922,14 +922,7 @@ I18n.translations.en = {
         },
     },
     locale: {
-        options: {
-            timeZone: "Europe/Amsterdam",
-            timeZoneName: "short",
-            hour: "2-digit",
-            minute: "2-digit",
-            second: "2-digit",
-            hour12: false,
-        }
+        timezone: "Europe/Amsterdam",
     }
 };
 

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -1,5 +1,5 @@
-import en from "locale/en";
 import { ENV } from "env";
+import en from "locale/en";
 import { merge } from "lodash";
 import { createIntl, createIntlCache } from "react-intl";
 import { apiClient } from "utils/ApplicationContext";
@@ -45,7 +45,7 @@ function parse_from_object(
         } else if (typeof msg == "string") {
             results[prefixed_id] = msg.replace(/\{\{/g, "{").replace(/\}\}/g, "}");
         } else {
-            results[prefixed_id] = msg
+            results[prefixed_id] = msg;
         }
     }
 }

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -1,4 +1,5 @@
 import en from "locale/en";
+import { ENV } from "env";
 import { merge } from "lodash";
 import { createIntl, createIntlCache } from "react-intl";
 import { apiClient } from "utils/ApplicationContext";
@@ -26,7 +27,7 @@ async function loadLocaleData(locale: string): Promise<Record<string, string>> {
             break;
     }
 
-    messages = merge(backend_messages, messages);
+    messages = merge(messages, backend_messages);
 
     return parse_translations_dict(messages);
 }
@@ -41,8 +42,10 @@ function parse_from_object(
 
         if (typeof msg === "object" && msg !== null) {
             parse_from_object(results, prefixed_id, msg);
-        } else {
+        } else if (typeof msg == "string") {
             results[prefixed_id] = msg.replace(/\{\{/g, "{").replace(/\}\}/g, "}");
+        } else {
+            results[prefixed_id] = msg
         }
     }
 }
@@ -63,7 +66,7 @@ const cache = createIntlCache();
 export let intl = createIntl(
     {
         // Locale of the application
-        locale: "en-GB",
+        locale: ENV.LOCALE,
         // Locale of the fallback defaultMessage
         defaultLocale: "en-GB",
         messages: parse_translations_dict(en),
@@ -76,7 +79,7 @@ export async function setLocale(locale: string) {
     intl = createIntl(
         {
             // Locale of the application
-            locale: locale,
+            locale: ENV.LOCALE,
             // Locale of the fallback defaultMessage
             defaultLocale: "en-GB",
             messages: await loadLocaleData(locale),

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -208,11 +208,11 @@ class App extends React.PureComponent<IProps, IState> {
             this.state.applicationContext.apiClient.products(),
             this.state.applicationContext.apiClient.assignees(),
             this.state.applicationContext.apiClient.processStatuses(),
-            setLocale("en-GB"),
+            setLocale(intl.locale),
             createPolicyCheck(this.props.user),
         ]);
 
-        const filteredProducts = (allProducts || []).sort((a, b) => a.name.localeCompare(b.name));
+        const filteredProducts = (allProducts || []).sort((a: { name: string; }, b: { name: any; }) => a.name.localeCompare(b.name));
 
         this.setState({
             loading: false,

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -212,7 +212,9 @@ class App extends React.PureComponent<IProps, IState> {
             createPolicyCheck(this.props.user),
         ]);
 
-        const filteredProducts = (allProducts || []).sort((a: { name: string; }, b: { name: any; }) => a.name.localeCompare(b.name));
+        const filteredProducts = (allProducts || []).sort((a: { name: string }, b: { name: any }) =>
+            a.name.localeCompare(b.name)
+        );
 
         this.setState({
             loading: false,


### PR DESCRIPTION
Though orchestrator-core stores all timestamps in UTC, the GUI currently displays the time in CET (Europe/Amsterdam) timezone. This value is hard-coded into the render function for timestamp cells.

The aim of this PR is to add the ability for an org to configure their desired timezone from the backend file, to remove the hard-coded `"en-GB"` locale string (passing in as an environment variable), and to use `moment-timezone` to convert timestamps to a proper time string.

In future, it would be nice to make the displayed timezone configurable via settings options per-user/client/browser in the web interface.