### PR TITLE
Fix UI Refresh Issue due to product_id Type Variance

### DIFF
--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -78,8 +78,10 @@ function ProcessDetail({ match, query, setQuery }: IProps) {
         if (stepUserInput && localStepUserInput) return;
         const localTabs = localStepUserInput ? ["user_input", "process"] : ["process"];
         const localSelectedTab = localStepUserInput ? "user_input" : "process";
-
-        setProductName(productNameById(processInstance.product, products));
+        const getProductId = (product: string | { product_id: string }) =>
+            typeof product === 'string' ? product : product.product_id;
+        const product_id = getProductId(processInstance.product);
+        setProductName(productNameById(product_id, products));
         setCustomerName(organisationNameByUuid(processInstance.customer, organisations));
         setProcess(processInstance);
         setStepUserInput(localStepUserInput);

--- a/src/pages/ProcessDetail.tsx
+++ b/src/pages/ProcessDetail.tsx
@@ -79,7 +79,7 @@ function ProcessDetail({ match, query, setQuery }: IProps) {
         const localTabs = localStepUserInput ? ["user_input", "process"] : ["process"];
         const localSelectedTab = localStepUserInput ? "user_input" : "process";
         const getProductId = (product: string | { product_id: string }) =>
-            typeof product === 'string' ? product : product.product_id;
+            typeof product === 'object' ? product : product.product_id;
         const product_id = getProductId(processInstance.product);
         setProductName(productNameById(product_id, products));
         setCustomerName(organisationNameByUuid(processInstance.customer, organisations));

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -234,7 +234,7 @@ export interface Process {
 export interface ProcessWithDetails {
     id: string;
     workflow_name: string;
-    product: string;
+    product: string | { product_id: string };
     customer: string;
     assignee: Assignee;
     last_status: string;


### PR DESCRIPTION
Resolved an issue where inconsistent `product_id` types caused the UI to stop refreshing. Adjusted type checking to handle both string and object forms of product_id.

