### PR TITLE
Add ping pong mechanic to websocket service to keep connection healthy

### DIFF
--- a/src/custom-example/uniforms/AutoFieldLoader.tsx
+++ b/src/custom-example/uniforms/AutoFieldLoader.tsx
@@ -2,6 +2,7 @@ import {
     AcceptField,
     BoolField,
     DateField,
+    DividerField,
     LabelField,
     ListField,
     LocationCodeField,
@@ -49,6 +50,8 @@ export function autoFieldFunction(props: GuaranteedProps<unknown> & Record<strin
                     return LongTextField;
                 case "label":
                     return LabelField;
+                case "divider":
+                    return DividerField;
                 case "summary":
                     return SummaryField;
                 case "subscription":

--- a/src/env.ts
+++ b/src/env.ts
@@ -64,5 +64,5 @@ export const ENV: Env = window.__env__ || {
     GITLAB_URL: process.env.REACT_APP_GITLAB_URL,
     CI_PROJECT_PATH: process.env.REACT_APP_CI_PROJECT_PATH,
     LOCALE: process.env.REACT_APP_LOCALE || "en-GB",
-    WS_PING_INTERVAL_IN_SECONDS: parseInt(process.env.WS_PING_INTERVAL_IN_SECONDS || "30000"),
+    WS_PING_INTERVAL_IN_SECONDS: parseInt(process.env.WS_PING_INTERVAL_IN_SECONDS || "30"),
 };

--- a/src/env.ts
+++ b/src/env.ts
@@ -33,6 +33,7 @@ interface Env {
     GITLAB_URL: string;
     CI_PROJECT_PATH: string;
     LOCALE: string;
+    WS_PING_INTERVAL_IN_SECONDS: number;
 }
 
 // We normally load env from window.__env__ as defined in public/env.js which
@@ -63,4 +64,5 @@ export const ENV: Env = window.__env__ || {
     GITLAB_URL: process.env.REACT_APP_GITLAB_URL,
     CI_PROJECT_PATH: process.env.REACT_APP_CI_PROJECT_PATH,
     LOCALE: process.env.REACT_APP_LOCALE || "en-GB",
+    WS_PING_INTERVAL_IN_SECONDS: parseInt(process.env.WS_PING_INTERVAL_IN_SECONDS || "30000"),
 };

--- a/src/websocketService/index.ts
+++ b/src/websocketService/index.ts
@@ -15,6 +15,7 @@ export interface SurfWebSocket<T> {
 }
 
 const pingMessage = "__ping__";
+const pingintervalInMilliseconds = ENV.WS_PING_INTERVAL_IN_SECONDS * 1000;
 
 const websocketSettings: Options = {
     retryOnError: true,
@@ -44,7 +45,7 @@ const useWebsocketServiceWithAuth = <T extends object>(endpoint: string): SurfWe
     }, [baseUrl, auth.userData?.access_token]);
 
     useEffect(() => {
-        const pingInterval = setInterval(() => sendMessage(pingMessage), ENV.WS_PING_INTERVAL_IN_SECONDS);
+        const pingInterval = setInterval(() => sendMessage(pingMessage), pingintervalInMilliseconds);
         return () => clearInterval(pingInterval);
     }, [sendMessage]);
 
@@ -71,7 +72,7 @@ const useWebsocketServiceWithoutAuth = <T extends object>(endpoint: string): Sur
     }, [readyState]);
 
     useEffect(() => {
-        const pingInterval = setInterval(() => sendMessage(pingMessage), ENV.WS_PING_INTERVAL_IN_SECONDS);
+        const pingInterval = setInterval(() => sendMessage(pingMessage), pingintervalInMilliseconds);
         return () => clearInterval(pingInterval);
     }, [sendMessage]);
 


### PR DESCRIPTION
the latest `react-use-websocket` has this feature built in and actually does something with the pong. but it's dependent on react 18 https://www.npmjs.com/package/react-use-websocket/v/4.5.0#heartbeat

- add divider into custom-example auto field loader