### PR TITLE
Remove in_use_by_relations from the subscription detail page

### DIFF
--- a/src/components/subscriptionDetail/templates/ServiceConfiguration.tsx
+++ b/src/components/subscriptionDetail/templates/ServiceConfiguration.tsx
@@ -98,6 +98,7 @@ export function RenderServiceConfiguration({
         const fields = Object.entries(instance)
             .filter(([key]) => !["label", "subscription_instance_id", "name"].includes(key))
             .filter(([key, value]) => (key === "owner_subscription_id" ? value !== subscription_id : true))
+            .filter(([key, value]) => key !== "in_use_by_relations")
             .map<[string, any]>(([key, value]) => {
                 return isArray(value) ? [key, value] : [key, [value]];
             });


### PR DESCRIPTION
this breaks subscription detail page with tabs showing only `-`