### PR TITLE
Fix position of Autocomplete component

### DIFF
--- a/src/custom-surf/components/inputForms/AutocompleteStyling.ts
+++ b/src/custom-surf/components/inputForms/AutocompleteStyling.ts
@@ -8,7 +8,6 @@ export const autocompleteStyling = css`
     }
 
     section.autocomplete {
-        position: absolute;
         z-index: 2000;
         top: 100%;
         width: 100%;

--- a/src/custom-surf/components/inputForms/AutocompleteStyling.ts
+++ b/src/custom-surf/components/inputForms/AutocompleteStyling.ts
@@ -12,7 +12,7 @@ export const autocompleteStyling = css`
         top: 100%;
         width: 100%;
         border-radius: ${SIZE_BORDER_RADIUS};
-        background-color: #787878;
+        background-color: #e0e0e0;
         margin-bottom: 25px;
 
         div.no-results {


### PR DESCRIPTION
Remove `position: absolute` from the Autocomplete component's css so that it renders at the correct place.
Also increased color contrast between text and background 

Fixes https://git.ia.surfsara.nl/netdev/automation/projects/orchestrator-client/-/issues/60