### PR TITLE
SelectField - Converts undefined to null

### DIFF
--- a/src/lib/uniforms-surfnet/src/SelectField.tsx
+++ b/src/lib/uniforms-surfnet/src/SelectField.tsx
@@ -112,7 +112,8 @@ function Select({
                         name={name}
                         onChange={(option) => {
                             if (!readOnly) {
-                                onChange(option?.value);
+                                // @ts-ignore
+                                onChange(option?.value ?? null);
                             }
                         }}
                         styles={customStyles}


### PR DESCRIPTION
In case of a modify flow we need to send the removal of a value to the backend. Before this change, it meant the value changes to `undefined`. However, `undefined` won't get sent to the backend (and backend does not allow a value to be `undefined`.

In case the value becomes `undefined` by clicking on the X on the select field, we change this value to `null`

Unfortunately ts-ignore is needed since onChange does not allow `null` as value.