### PR TITLE
Add CustomerId field

### DIFF
--- a/src/custom-surf/uniforms/AutoFieldLoader.tsx
+++ b/src/custom-surf/uniforms/AutoFieldLoader.tsx
@@ -6,6 +6,7 @@ import VlanField from "custom/uniforms/VlanField";
 import {
     AcceptField,
     BoolField,
+    CustomerField,
     DateField,
     DividerField,
     LabelField,
@@ -59,6 +60,8 @@ export function autoFieldFunction(props: GuaranteedProps<unknown> & Record<strin
                     return LocationCodeField;
                 case "organisationId":
                     return OrganisationField;
+                case "customerId":
+                    return CustomerField;
                 case "contactPersonName":
                     return ContactPersonNameField;
                 case "vlan":

--- a/src/lib/uniforms-surfnet/src/index.ts
+++ b/src/lib/uniforms-surfnet/src/index.ts
@@ -43,4 +43,5 @@ export { default as SummaryField } from "lib/uniforms-surfnet/src/SummaryField";
 
 export { default as LocationCodeField } from "lib/uniforms-surfnet/src/logic/LocationCodeField";
 export { default as OrganisationField } from "lib/uniforms-surfnet/src/logic/OrganisationField";
+export { default as CustomerField } from "lib/uniforms-surfnet/src/logic/CustomerField";
 export { default as ProductField } from "lib/uniforms-surfnet/src/logic/ProductField";

--- a/src/lib/uniforms-surfnet/src/logic/CustomerField.tsx
+++ b/src/lib/uniforms-surfnet/src/logic/CustomerField.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-2023 SURF.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SelectField, { SelectFieldProps } from "lib/uniforms-surfnet/src/SelectField";
+import get from "lodash/get";
+import React, { useContext } from "react";
+import { useIntl } from "react-intl";
+import { connectField } from "uniforms";
+import ApplicationContext from "utils/ApplicationContext";
+
+export type CustomerFieldProps = Omit<SelectFieldProps, "placeholder" | "transform" | "allowedValues">;
+
+function Customer({ name, ...props }: CustomerFieldProps) {
+    const intl = useIntl();
+    const { organisations } = useContext(ApplicationContext);
+    const customerLabelLookup =
+        organisations?.reduce<{ [index: string]: string }>(function (mapping, org) {
+            mapping[org.uuid] = org.name;
+            return mapping;
+        }, {}) ?? {};
+
+    return (
+        <SelectField
+            name=""
+            {...props}
+            allowedValues={Object.keys(customerLabelLookup)}
+            transform={(uuid: string) => get(customerLabelLookup, uuid, uuid)}
+            placeholder={intl.formatMessage({ id: "forms.widgets.customer.placeholder" })}
+        />
+    );
+}
+
+export default connectField(Customer);

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -107,6 +107,9 @@ I18n.translations.en = {
             organisation: {
                 placeholder: "Search and select a customer...",
             },
+            customer: {
+                placeholder: "Search and select a customer...",
+            },
             product: {
                 placeholder: "Search and select a product...",
             },


### PR DESCRIPTION
we are renaming organisation to customer in the backend, so made some changes to make V1 compatible for new and old backend versions.
- new CustomerId field to work with `CustomerId` type in backend.
- update SubscriptionField to work with customer as wel as organisation properties.