### PR TITLE
Configurable date and time render fns

### DIFF
--- a/src/utils/Lookups.ts
+++ b/src/utils/Lookups.ts
@@ -1,3 +1,5 @@
+import { intl } from "locale/i18n";
+import moment from "moment-timezone";
 /*
  * Copyright 2019-2023 SURF.
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,13 +49,35 @@ export function productById(id: string, products: Product[]): Product {
 }
 
 export function renderDateTime(epoch: number) {
-    // Todo: locale should be configurable for GPL
-    return isEmpty(epoch) ? "" : new Date(epoch * 1000).toLocaleString("nl-NL");
+    // Convert timestamp to ISO8601-like format.
+    // Example:
+    //   2023-07-12 15:16:32 CEST
+    if (!epoch) {
+        return "";
+    }
+    // get milliseconds for unix timestamp
+    const time = moment(epoch * 1000);
+    // get timezone from translations object
+    const timezone = intl.formatMessage({ id: "locale.timezone" });
+    const format = "y-MM-DD HH:mm:ss z";
+
+    return time.tz(timezone).format(format);
 }
 
 export function renderDate(epoch: number) {
-    // Todo: locale should be configurable for GPL
-    return isEmpty(epoch) ? "" : new Date(epoch * 1000).toLocaleDateString("nl-NL");
+    // Convert timestamp to ISO8601 Date string
+    // Example:
+    //   2023-07-12
+    if (!epoch) {
+        return "";
+    }
+    // get milliseconds for unix timestamp
+    const time = moment(epoch * 1000);
+    // get timezone from translations object
+    const timezone = intl.formatMessage({ id: "locale.timezone" });
+    const format = "y-MM-DD";
+
+    return time.tz(timezone).format(format);
 }
 
 export function capitalize(s: string) {


### PR DESCRIPTION
Removing the hard-coded "nl-NL" locale from date rendering functions (which are used everywhere besides the Subscription Table view right now, as far as I know).

ISO8601 is the format I went with for these two functions, but we could keep the `toLocale{Date}String` functions as well, if that format is desired.